### PR TITLE
Replace usage of row effects in Search primitive & update docs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,15 +28,15 @@
     "dist"
   ],
   "dependencies": {
-    "purescript-halogen": "^3.0.1",
+    "purescript-halogen": "^3.1.1",
     "purescript-control": "^3.3.1",
     "purescript-transformers": "^3.5.0",
-    "purescript-dom": "^4.13.2",
+    "purescript-dom": "^4.15.0",
     "purescript-affjax": "^5.0.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",
-    "purescript-css": "^3.3.0",
+    "purescript-css": "^3.4.0",
     "purescript-halogen-css": "^7.0.0",
     "purescript-datetime": "^3.4.1",
     "purescript-formatters": "^3.0.1",

--- a/bower.json
+++ b/bower.json
@@ -41,6 +41,7 @@
     "purescript-datetime": "^3.4.1",
     "purescript-formatters": "^3.0.1",
     "purescript-debug": "^3.0.0",
-    "purescript-now": "^3.0.0"
+    "purescript-now": "^3.0.0",
+    "purescript-js-timers": "^3.0.0"
   }
 }

--- a/examples/calendar/src/Calendar.purs
+++ b/examples/calendar/src/Calendar.purs
@@ -42,9 +42,8 @@ data Query a
 
 data Direction = Prev | Next
 
-type FX e = Aff (CalendarEffects e)
-type CalendarEffects e = (Effects (now :: NOW | e))
-type ParentHTML e = H.ParentHTML Query ChildQuery Unit (FX e)
+type CalendarEffects e = (now :: NOW | Effects e)
+type ParentHTML e = H.ParentHTML Query ChildQuery Unit (Aff (CalendarEffects e))
 type ChildQuery = C.ContainerQuery Query CalendarItem
 
 ----------
@@ -65,7 +64,7 @@ data BoundaryStatus
   | InBounds
 
 
-component :: ∀ e. H.Component HH.HTML Query Unit Void (FX e)
+component :: ∀ e. H.Component HH.HTML Query Unit Void (Aff (CalendarEffects e))
 component =
   H.lifecycleParentComponent
     { initialState
@@ -80,7 +79,7 @@ component =
     initialState = const
       { targetDate: Tuple (unsafeMkYear 2019) (unsafeMkMonth 2) }
 
-    eval :: Query ~> H.ParentDSL State Query ChildQuery Unit Void (FX e)
+    eval :: Query ~> H.ParentDSL State Query ChildQuery Unit Void (Aff (CalendarEffects e))
     eval = case _ of
       ToContainer q a -> H.query unit q *> pure a
 
@@ -122,7 +121,7 @@ component =
          pure a
 
 
-    render :: State -> H.ParentHTML Query ChildQuery Unit (FX e)
+    render :: State -> H.ParentHTML Query ChildQuery Unit (Aff (CalendarEffects e))
     render st =
       HH.div
         [ HP.class_ $ HH.ClassName "mw8 sans-serif center" ]
@@ -143,7 +142,7 @@ component =
         targetYear  = fst st.targetDate
         targetMonth = snd st.targetDate
 
-        renderToggle :: H.ParentHTML Query ChildQuery Unit (FX e)
+        renderToggle :: H.ParentHTML Query ChildQuery Unit (Aff (CalendarEffects e))
         renderToggle =
           HH.span
           ( C.getToggleProps ToContainer

--- a/examples/dropdown/src/Dropdown.purs
+++ b/examples/dropdown/src/Dropdown.purs
@@ -2,6 +2,7 @@ module Dropdown where
 
 import Prelude
 
+import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.Console (log, logShow)
 import CSS as CSS
 import DOM.Event.KeyboardEvent as KE
@@ -12,7 +13,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.HTML.CSS as HC
-import Select.Effects (FX)
+import Select.Effects (Effects)
 import Select.Primitives.Container as C
 
 type DropdownItem = String
@@ -26,9 +27,7 @@ data Query a
   | HandleContainer (C.Message Query DropdownItem) a
   | ToContainer (C.ContainerQuery Query DropdownItem Unit) a
 
-type HTML e = H.ParentHTML Query (C.ContainerQuery Query DropdownItem) Unit (FX e)
-
-component :: ∀ e. H.Component HH.HTML Query Unit Void (FX e)
+component :: ∀ e. H.Component HH.HTML Query Unit Void (Aff (Effects e))
 component =
   H.parentComponent
     { initialState: const initState
@@ -40,7 +39,7 @@ component =
     initState :: State
     initState = { items: testData, selected: [] }
 
-    render :: State -> H.ParentHTML Query (C.ContainerQuery Query DropdownItem) Unit (FX e)
+    render :: State -> H.ParentHTML Query (C.ContainerQuery Query DropdownItem) Unit (Aff (Effects e))
     render st =
       HH.div
         [ HP.class_ $ HH.ClassName "mw8 sans-serif center" ]
@@ -69,7 +68,7 @@ component =
     -- Here, Menu.Emit recursively calls the parent eval function.
     -- Menu.Selected item is handled by removing that item from
     -- the options and maintaining it here in state.
-    eval :: Query ~> H.ParentDSL State Query (C.ContainerQuery Query DropdownItem) Unit Void (FX e)
+    eval :: Query ~> H.ParentDSL State Query (C.ContainerQuery Query DropdownItem) Unit Void (Aff (Effects e))
     eval = case _ of
       Log s a -> H.liftAff (log s) *> pure a
 
@@ -117,7 +116,7 @@ testData =
 
 -- Render whatever is going to provide the action for toggling the menu. Notably, this is
 -- NOT a primitive.
-renderToggle :: ∀ e. HTML e
+renderToggle :: ∀ e. H.ParentHTML Query (C.ContainerQuery Query DropdownItem) Unit (Aff (Effects e))
 renderToggle =
   HH.span
     ( C.getToggleProps ToContainer

--- a/examples/dropdown/src/Main.purs
+++ b/examples/dropdown/src/Main.purs
@@ -8,7 +8,7 @@ import Halogen.VDom.Driver (runUI)
 import Dropdown (component)
 import Select.Effects (Effects)
 
-main :: ∀ e. Eff (HA.HalogenEffects (Effects e)) Unit
+main :: ∀ e. Eff (Effects e) Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
   runUI component unit body

--- a/examples/typeahead/src/Main.purs
+++ b/examples/typeahead/src/Main.purs
@@ -5,9 +5,9 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
-import Typeahead (TypeaheadEffects, component)
+import Example.Typeahead.Parent (MyEffects, component)
 
-main :: ∀ e. Eff (TypeaheadEffects e) Unit
+main :: ∀ e. Eff (MyEffects e) Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
   runUI component unit body

--- a/examples/typeahead/src/Main.purs
+++ b/examples/typeahead/src/Main.purs
@@ -5,7 +5,6 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
-import Select.Effects (Effects)
 import Typeahead (TypeaheadEffects, component)
 
 main :: ∀ e. Eff (TypeaheadEffects e) Unit

--- a/examples/typeahead/src/Main.purs
+++ b/examples/typeahead/src/Main.purs
@@ -6,9 +6,9 @@ import Control.Monad.Eff (Eff)
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
 import Select.Effects (Effects)
-import Typeahead (component)
+import Typeahead (TypeaheadEffects, component)
 
-main :: Eff _ Unit
+main :: ∀ e. Eff (TypeaheadEffects e) Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
   runUI component unit body

--- a/examples/typeahead/src/Main.purs
+++ b/examples/typeahead/src/Main.purs
@@ -8,7 +8,7 @@ import Halogen.VDom.Driver (runUI)
 import Select.Effects (Effects)
 import Typeahead (component)
 
-main :: forall e. Eff (HA.HalogenEffects (Effects e)) Unit
+main :: Eff _ Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
   runUI component unit body

--- a/examples/typeahead/src/Parent.purs
+++ b/examples/typeahead/src/Parent.purs
@@ -11,9 +11,8 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 
 import Example.Typeahead.Child as Child
-import Select.Effects (Effects)
 
-type MyEffects e = ( now :: NOW | Effects e)
+type MyEffects e = ( now :: NOW | Child.TypeaheadEffects e)
 
 data Query a
   = HandleTypeahead Int Child.Message a

--- a/examples/typeahead/src/Parent.purs
+++ b/examples/typeahead/src/Parent.purs
@@ -1,0 +1,75 @@
+module Example.Typeahead.Parent where
+
+import Prelude
+
+import Control.Monad.Eff.Now (NOW, now)
+import Control.Monad.Aff.Class (class MonadAff)
+import Data.Maybe (Maybe(..))
+
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+
+import Example.Typeahead.Child as Child
+import Select.Effects (Effects)
+
+type MyEffects e = ( now :: NOW | Effects e)
+
+data Query a
+  = HandleTypeahead Int Child.Message a
+
+type ChildSlot = Slot
+type ChildQuery = Child.Query
+
+data Slot = Slot Int
+derive instance eqSlot :: Eq Slot
+derive instance ordSlot :: Ord Slot
+
+component :: ∀ m e
+  . MonadAff ( MyEffects e ) m
+ => H.Component HH.HTML Query Unit Void m
+component =
+  H.parentComponent
+    { initialState: const unit
+    , render
+    , eval
+    , receiver: const Nothing
+    }
+  where
+    render :: Unit -> H.ParentHTML Query ChildQuery ChildSlot m
+    render _ =
+      HH.div_
+        [ HH.slot (Slot 1) Child.component pres (HE.input (HandleTypeahead 1))
+        , HH.slot (Slot 2) Child.component dev (HE.input (HandleTypeahead 2)) ]
+
+    eval :: Query ~> H.ParentDSL Unit Query ChildQuery ChildSlot Void m
+    eval (HandleTypeahead _ _ next) = pure next
+
+
+----------
+-- Data
+
+pres :: Array String
+pres =
+  [ "Barack Obama"
+  , "George W. Bush"
+  , "Bill Clinton"
+  , "George H. W. Bush"
+  ]
+
+dev :: Array String
+dev =
+  [ "Thomas Honeyman"
+  , "Dave Zuch"
+  , "Chris Cornwell"
+  , "Forest Toney"
+  , "Lee Leathers"
+  , "Kim Wu"
+  , "Rachel Blair"
+  , "Tara Strauss"
+  , "Sanket Sabnis"
+  , "Aaron Chu"
+  , "Vincent Busam"
+  , "Riley Gibbs"
+  ]
+

--- a/examples/typeahead/src/Typeahead.purs
+++ b/examples/typeahead/src/Typeahead.purs
@@ -19,10 +19,8 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.HTML.CSS as HC
-import Select.Effects (Effects)
 import Select.Primitives.Container as C
 import Select.Primitives.Search as S
-
 
 type TypeaheadItem = String
 
@@ -31,17 +29,15 @@ data Query a
   | HandleContainer (C.Message Query TypeaheadItem) a
   | HandleSearch    (S.Message Query TypeaheadItem) a
 
-type ChildQuery e = Coproduct2 (C.ContainerQuery Query TypeaheadItem) (S.SearchQuery Query TypeaheadItem (Effects e))
+type ChildQuery e = Coproduct2 (C.ContainerQuery Query TypeaheadItem) (S.SearchQuery Query TypeaheadItem e)
 type ChildSlot = Either2 Unit Unit
-
-type HTML m e = H.ParentHTML Query (ChildQuery e) ChildSlot m
 
 type State =
   { items    :: Array TypeaheadItem
   , selected :: Array TypeaheadItem }
 
-component :: ∀ e m
-  . MonadAff ( Effects e ) m
+component :: ∀ m
+  . MonadAff _ m
  => H.Component HH.HTML Query Unit Void m
 component =
   H.parentComponent
@@ -54,7 +50,7 @@ component =
     initState :: State
     initState = { items: testData, selected: [] }
 
-    render :: State -> HTML m e
+    render :: State -> H.ParentHTML Query (ChildQuery _) ChildSlot m
     render st =
       HH.div
         [ HP.class_ $ HH.ClassName "mw8 sans-serif center" ]
@@ -75,7 +71,7 @@ component =
             ( HE.input HandleContainer )
         ]
 
-    eval :: Query ~> H.ParentDSL State Query (ChildQuery e) ChildSlot Void m
+    eval :: Query ~> H.ParentDSL State Query (ChildQuery _) ChildSlot Void m
     eval = case _ of
       Log str a -> a <$ do
         H.liftAff $ log str

--- a/examples/typeahead/src/Typeahead.purs
+++ b/examples/typeahead/src/Typeahead.purs
@@ -91,6 +91,7 @@ component =
 
           x <- H.liftEff now
           H.liftAff $ log $ "New search performed: " <> s
+          H.liftAff $ log $ "Time: " <> show x
 
           let filtered  = filterItems s st.items
           let available = difference filtered st.selected

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "pulp": "^12.0.1",
-    "purescript": "^0.11.6"
+    "purescript": "^0.11.7"
   }
 }

--- a/src/Effects.purs
+++ b/src/Effects.purs
@@ -1,17 +1,15 @@
 module Select.Effects where
 
+import Control.Monad.Eff.Ref (REF)
 import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Aff.Console (CONSOLE)
 import DOM (DOM)
 import Network.HTTP.Affjax (AJAX)
 
--- | The primitive Effects type, wrapped in Aff. This is used for convenience over Effects.
-type FX e = Aff (Effects e)
-
 -- | The primitive Effects type. To extend your own component with this type, you might do:
 -- |
 -- | ```purescript
 -- | main :: ∀ e. Eff (HalogenEffects (Effects e)) Unit
 -- | ```
-type Effects e = ( dom :: DOM, console :: CONSOLE, ajax :: AJAX, avar :: AVAR | e)
+type Effects eff = ( dom :: DOM, console :: CONSOLE, ajax :: AJAX, avar :: AVAR, ref :: REF | eff )

--- a/src/Effects.purs
+++ b/src/Effects.purs
@@ -1,5 +1,6 @@
 module Select.Effects where
 
+import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Ref (REF)
 import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.AVar (AVAR)
@@ -12,4 +13,4 @@ import Network.HTTP.Affjax (AJAX)
 -- | ```purescript
 -- | main :: ∀ e. Eff (HalogenEffects (Effects e)) Unit
 -- | ```
-type Effects eff = ( dom :: DOM, console :: CONSOLE, ajax :: AJAX, avar :: AVAR, ref :: REF | eff )
+type Effects eff = ( dom :: DOM, console :: CONSOLE, ajax :: AJAX, avar :: AVAR, ref :: REF, exception :: EXCEPTION | eff )

--- a/src/Effects.purs
+++ b/src/Effects.purs
@@ -8,9 +8,17 @@ import Control.Monad.Aff.Console (CONSOLE)
 import DOM (DOM)
 import Network.HTTP.Affjax (AJAX)
 
--- | The primitive Effects type. To extend your own component with this type, you might do:
+-- | The effect rows used in all primitives. To extend this type in a parent component, you
+-- | can add your own effects:
 -- |
 -- | ```purescript
--- | main :: ∀ e. Eff (HalogenEffects (Effects e)) Unit
+-- | type MyEffects e = ( effect :: EFFECT | Effects e )
+-- | ```
+-- |
+-- | Note: When using the Search primitive, make sure you provide effects extended by Effects, rather than your own
+-- | effects directly. Using the above MyEffects example:
+-- |
+-- | ```purescript
+-- | type ChildQuery e = SearchQuery MyQuery MyItem (MyEffects e)
 -- | ```
 type Effects eff = ( dom :: DOM, console :: CONSOLE, ajax :: AJAX, avar :: AVAR, ref :: REF, exception :: EXCEPTION | eff )

--- a/src/Primitives/Container.purs
+++ b/src/Primitives/Container.purs
@@ -5,6 +5,7 @@ import Prelude
 import Control.Comonad (extract)
 import Control.Comonad.Store (seeks, store)
 import Control.Monad.Aff.Console (log)
+import Control.Monad.Aff.Class (class MonadAff)
 import Data.Array (length, (!!))
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
@@ -16,7 +17,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Select.Primitives.State (updateStore, getState, State)
-import Select.Effects (FX)
+import Select.Effects (Effects)
 
 
 -- | The query type for the `Container` primitive.
@@ -91,7 +92,9 @@ data Message o item
 -- | The primitive handles state and transformations but defers all rendering to the parent. The
 -- | render function can be written using our helper functions to ensure the right events are included. See the `Dispatch`
 -- | module for more information.
-component :: ∀ item o e. H.Component HH.HTML (ContainerQuery o item) (ContainerInput o item) (Message o item) (FX e)
+component :: ∀ item o e m
+  . MonadAff ( Effects e ) m
+ => H.Component HH.HTML (ContainerQuery o item) (ContainerInput o item) (Message o item) m
 component =
   H.component
     { initialState
@@ -109,7 +112,13 @@ component =
       , mouseDown: false
       }
 
-    eval :: (ContainerQuery o item) ~> H.ComponentDSL (State (ContainerState item) (ContainerQuery o item)) (ContainerQuery o item) (Message o item) (FX e)
+    eval
+      :: (ContainerQuery o item)
+      ~> H.ComponentDSL
+          (State (ContainerState item) (ContainerQuery o item))
+          (ContainerQuery o item)
+          (Message o item)
+          m
     eval = case _ of
       Raise q a -> do
         H.raise $ Emit q

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -6,7 +6,7 @@ import Data.Time.Duration (Milliseconds)
 import DOM.Event.Types as ET
 import Control.Comonad (extract)
 import Control.Comonad.Store (seeks, store)
-import Control.Monad.Aff (Fiber, delay, error, forkAff, killFiber)
+import Control.Monad.Aff (Aff, Fiber, delay, error, forkAff, killFiber)
 import Control.Monad.Aff.AVar (AVar, makeEmptyVar, putVar, takeVar)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Tuple (Tuple(..))
@@ -17,7 +17,7 @@ import Halogen.HTML.Properties as HP
 import Halogen.Query.HalogenM (fork, raise) as H
 import Select.Primitives.State (State, updateStore, getState)
 import Select.Primitives.Container as C
-import Select.Effects (Effects, FX)
+import Select.Effects (Effects)
 
 {-
 
@@ -51,7 +51,7 @@ type SearchState e =
 -- | The `Debouncer` type alias, used to debounce user input in the `Search` primitive.
 type Debouncer e =
   { var   :: AVar Unit
-  , fiber :: Fiber (Effects e) Unit }
+  , fiber :: Fiber e Unit }
 
 -- | The input type of the `Search` primitive
 -- |
@@ -77,7 +77,7 @@ data Message o item
 -- | The primitive handles state and transformations but defers all rendering to the parent. The
 -- | render function can be written using our helper functions to ensure the right events are included. See the `Dispatch`
 -- | module for more information.
-component :: ∀ o item e. H.Component HH.HTML (SearchQuery o item e) (SearchInput o item e) (Message o item) (FX e)
+component :: ∀ o item e. H.Component HH.HTML (SearchQuery o item e) (SearchInput o item e) (Message o item) (Aff (Effects e))
 component =
   H.component
     { initialState
@@ -93,7 +93,7 @@ component =
       , debouncer: Nothing
       }
 
-    eval :: (SearchQuery o item e) ~> H.ComponentDSL (State (SearchState e) (SearchQuery o item e)) (SearchQuery o item e) (Message o item) (FX e)
+    eval :: (SearchQuery o item e) ~> H.ComponentDSL (State (SearchState e) (SearchQuery o item e)) (SearchQuery o item e) (Message o item) (Aff (Effects e))
     eval = case _ of
       TextInput str a -> a <$ do
         (Tuple _ st) <- getState

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -1,3 +1,7 @@
+-- | The Search primitive captures and debounces user input. It can be used in conjunction
+-- | with the Container primitive to make search-driven selection components like
+-- | typeaheads, image pickers, and date pickers.
+
 module Select.Primitives.Search where
 
 import Prelude
@@ -20,56 +24,97 @@ import Select.Primitives.State (State, updateStore, getState)
 import Select.Primitives.Container as C
 import Select.Effects (Effects)
 
-{-
-
-The Search primitive captures user input and returns it to the parent.
-
--}
-
 -- | The query type for the `Search` primitive. This primitive handles text input
--- | and debouncing.
+-- | and debouncing. It has a special query for the purpose of embedding Container
+-- | queries, used to route key events to the container from an input field.
+-- |
+-- | Arguments:
+-- |
+-- | - `o`: The type of the parent query to embed. This is usually the component that
+-- | -      mounts the search primitive, but it could also be the query type of some
+-- |        higher component.
+-- | - `item`: Your custom item type, used by your renderers.
+-- | - `eff`: The row of effects to use in the primitive. You are expected to provide your
+-- |          rows wrapped in the select Effects type:
+-- |
+-- | ```purescript
+-- | type ChildQuery eff = SearchQuery MyQuery MyItem (Effects eff)
+-- | ```
+-- |
+-- | Constructors:
 -- |
 -- | - `TextInput`: Handle new text input as a string
+-- | - `Raise`: Embed a parent query that can be returned to the parent for evaluation
+-- | - `FromContainer`: Embed a container query that can be routed to a container slot
 -- | - `SearchReceiver`: Update the component with new `Input` when the parent re-renders
-data SearchQuery o item e a
+data SearchQuery o item eff a
   = TextInput String a
   | Raise (o Unit) a
   | FromContainer (C.ContainerQuery o item Unit) a
-  | SearchReceiver (SearchInput o item e) a
+  | SearchReceiver (SearchInput o item eff) a
 
--- | The `Search` primitive internal state
+-- | The `Search` primitive internal state.
 -- |
--- | - `search`: The `String` contained within the primitive
+-- | Arguments:
+-- |
+-- | - `eff`: The row of effects used in the primivite. This needs to be wrapped in the
+-- |          effects type in practice:
+-- |
+-- | ```purescript
+-- | forall e. SearchState (Effects e)
+-- | ```
+-- |
+-- | Fields:
+-- |
+-- | - `search`: The `String` contained within the primitive. This is captured from user
+-- |             input, or can be set by the parent.
 -- | - `ms`: Number of milliseconds for the input to be debounced before passing
 -- |         a message to the parent. Set to 0.0 if you don't want debouncing.
--- | - `debouncer`: Used to facilitate debouncing of the input
-type SearchState e =
+-- | - `debouncer`: Facilitates debouncing for the input field.
+type SearchState eff =
   { search    :: String
   , ms        :: Milliseconds
-  , debouncer :: Maybe (Debouncer e)
+  , debouncer :: Maybe (Debouncer eff)
   }
 
 -- | The `Debouncer` type alias, used to debounce user input in the `Search` primitive.
-type Debouncer e =
+type Debouncer eff =
   { var   :: AVar Unit
-  , fiber :: Fiber e Unit }
+  , fiber :: Fiber eff Unit }
 
 -- | The input type of the `Search` primitive
 -- |
+-- | Fields:
+-- |
 -- | - `search`: An optional initial value for the `search` key on the `SearchState`
 -- | - `debounceTime`: A value in milliseconds for the debounce delay. Set to 0.0 for
--- | no debouncing.
+-- |                   no debouncing.
 -- | - `render`: The render function for the primitive
-type SearchInput o item e =
+type SearchInput o item eff =
   { search :: Maybe String
   , debounceTime :: Milliseconds
-  , render :: SearchState e -> H.ComponentHTML (SearchQuery o item e) }
+  , render :: SearchState eff -> H.ComponentHTML (SearchQuery o item eff) }
 
 
--- | The Search sends the parent messages in two instances:
--- | - `Emit`: An embedded query has been triggered, and you must decide how to handle it; typically via evaluating
--- |           in the parent or re-routing the query to another primitive.
--- | - `NewSearch`: Some new text has been searched (this is automatically debounced).
+-- | The possible messages a parent can evaluate from the search primitive.
+-- |
+-- | Constructors:
+-- |
+-- | - `NewSearch`: The user has entered a new search and it has passed the debouncer.
+-- | - `ContainerQuery`: The user has triggered an embedded container query, like using arrow
+-- |                     keys or Enter to select an item. Usually, you will route this to the
+-- |                     container associated with your search primitive.
+-- |
+-- | ```purescript
+-- | eval (HandleSearch (Emit q))
+-- | ```
+-- |
+-- | - `Emit`: An embedded parent query has been triggered. This can be evaluated automatically
+-- |           with this code in the parent's eval function:
+-- |
+-- | ```purescript
+-- | eval (HandleSearch (Emit q))
+-- | ```
 data Message o item
   = NewSearch String
   | ContainerQuery (C.ContainerQuery o item Unit)
@@ -77,15 +122,13 @@ data Message o item
 
 
 -- | The primitive handles state and transformations but defers all rendering to the parent. The
--- | render function can be written using our helper functions to ensure the right events are included. See the `Dispatch`
--- | module for more information.
-
-component :: ∀ o item e m
-  . MonadAff (Effects e) m
+-- | render function can be written using our helper functions to ensure the right events are included.
+component :: ∀ o item eff m
+  . MonadAff (Effects eff) m
  => H.Component
      HH.HTML
-     (SearchQuery o item (Effects e))
-     (SearchInput o item (Effects e))
+     (SearchQuery o item (Effects eff))
+     (SearchInput o item (Effects eff))
      (Message o item)
      m
 component =
@@ -97,8 +140,8 @@ component =
     }
   where
     initialState
-      :: SearchInput o item (Effects e)
-      -> State (SearchState (Effects e)) (SearchQuery o item (Effects e))
+      :: SearchInput o item (Effects eff)
+      -> State (SearchState (Effects eff)) (SearchQuery o item (Effects eff))
     initialState i = store i.render
       { search: fromMaybe "" i.search
       , ms: i.debounceTime
@@ -106,11 +149,11 @@ component =
       }
 
     eval
-      :: (SearchQuery o item (Effects e))
+      :: (SearchQuery o item (Effects eff))
       ~> H.ComponentDSL
-          (State (SearchState (Effects e))
-          (SearchQuery o item (Effects e)))
-          (SearchQuery o item (Effects e))
+          (State (SearchState (Effects eff))
+          (SearchQuery o item (Effects eff)))
+          (SearchQuery o item (Effects eff))
           (Message o item)
           m
     eval = case _ of
@@ -158,8 +201,15 @@ component =
       SearchReceiver i a -> H.modify (updateStore i.render id) *> pure a
 
 
-
-getInputProps :: ∀ o item e e0
+-- | Attach the necessary properties to the input field you render in the page. This
+-- | should be used directly on the input field's list of properties:
+-- |
+-- | ```purescript
+-- | input_ $ getInputProps [ class_ (ClassName "my-class"), placeholder "Search..." ]
+-- | ```
+-- |
+-- | Note: This will overwrite any existing properties of the same name.
+getInputProps :: ∀ o item e eff
    . Array
       (H.IProp
         ( onFocus :: ET.FocusEvent
@@ -172,7 +222,7 @@ getInputProps :: ∀ o item e e0
         , tabIndex :: Int
         | e
         )
-        (SearchQuery o item e0)
+        (SearchQuery o item eff)
       )
   -> Array
       (H.IProp
@@ -186,7 +236,7 @@ getInputProps :: ∀ o item e e0
         , tabIndex :: Int
         | e
         )
-        (SearchQuery o item e0)
+        (SearchQuery o item eff)
       )
 getInputProps = flip (<>)
   [ HE.onFocus      $ HE.input_ $ FromContainer $ H.action $ C.Visibility C.Toggle

--- a/src/Primitives/State.purs
+++ b/src/Primitives/State.purs
@@ -1,3 +1,23 @@
+-- | All primitives use the `Store` comonad as their component state. They also
+-- | define their own state as is typical for Halogen Components, which is in turn
+-- | embedded in `Store`.
+-- |
+-- | Note: Unless you are modifying or defining a new primitive, you will not need to use this type
+-- | and can rely on the usual state definitions in each primitive's module.
+-- |
+-- | **Why use `Store`?**
+-- | Halogen components only update if new values come in via their `receiver` field using their `Input`
+-- | type, or if they are destroyed and re-initialized in a new slot. Most values can be updated this
+-- | way, but not render functions.
+-- |
+-- | In this library, we do not make any rendering decisions and leave it entirely up to you to decide
+-- | how your selection component should appear. Your render functions have access to the parent state
+-- | in which you mounted the primitive. This means you can provide arbitrary data to the primitive by
+-- | storing it in the parent state and accessing it in the renderer.
+-- |
+-- | Therefore, it is necessary that your render function updates on parent re-render just like usual
+-- | `Input` values. Using `Store` allows us to extract and use the render function in a primitive.
+
 module Select.Primitives.State where
 
 import Prelude (pure, (<<<), (=<<))
@@ -8,20 +28,13 @@ import Control.Monad.State (class MonadState)
 import Halogen as H
 
 -- | All primitives use the `Store` type as their component state. Any additional
--- | data, like a traditional Halogen State record, will usually be provided.
--- |
--- | Note: It's necessary to use a `Store` comonad as the state type for primitives
--- | because they receive their render function as input. The render function cannot
--- | be stored in the State type synonym due to cycles, and as your component render
--- | function can only take `State` as its input, you need the render function available
--- | via the comonad, StoreT.
+-- | data, like a traditional Halogen State record, will also be provided.
 -- |
 -- | - `s`: The state type defined for the primitive
--- |
 -- | - `q`: The query type defined for the primitive
 type State s q = Store s (H.ComponentHTML q)
 
--- | Helper to get and unpack the primitive state type from the Store type. When used with pattern matching,
+-- | A helper to get and unpack the primitive state type from the Store type. When used with pattern matching,
 -- | you can access state with:
 -- |
 -- | ```purescript
@@ -30,9 +43,10 @@ type State s q = Store s (H.ComponentHTML q)
 getState :: ∀ m s a. MonadState (Store s a) m => m (Tuple (s -> a) s)
 getState = pure <<< runStore =<< H.get
 
--- | Helper for wholly updating the `State` (`Store`) of a primitive.
+-- | A helper for wholly updating the `State` (`Store`) of a primitive.
 -- |
--- | Used when the `render` function needs to be updated.
+-- | Used when the `render` function needs to be updated; this is typically in the
+-- | query that handles `Input` updates.
 -- |
 -- | Note: Use `seeks` if only the primitive's internal state needs to be updated (not the entire Store).
 updateStore :: ∀ state html. (state -> html) -> (state -> state) -> Store state html -> Store state html


### PR DESCRIPTION
### What does this pull request do?

Overhauls how we use effect rows in the Search primitive so that they can be extended with arbitrary effects by the parent. Also provides documentation on how to do this, adds a working example in `/examples/typeahead`, and updates docs across the board as they have fallen out of date.

Fixes a critical issue in which using the Search primitive would prevent the end user from being able to use new effects even higher in their stack (as seen in `purescript-cn-ui`). We had tested adding arbitrary effects with the Container primitive (which worked), but not the Search primitive.

### Where should the reviewer start?

Review the search primitive and new example effect types.

### Other Notes:

This should release a new version of the library (0.2).