### PR TITLE
Search container

### DIFF
--- a/docs/site/config.toml
+++ b/docs/site/config.toml
@@ -1,5 +1,5 @@
 # The base URL pages are relative to
-base_url = "https://citizennet.github.io/purescript-halogen-select"
+base_url = "/purescript-halogen-select/"
 
 # Don't provide or compile from Sass folder
 compile_sass = true

--- a/docs/src/App/Component.purs
+++ b/docs/src/App/Component.purs
@@ -35,7 +35,7 @@ type Effects eff = ( console :: CONSOLE, dom :: DOM, now :: NOW, avar :: AVAR, t
 ----------
 -- Built components
 
-dropdown :: ∀ t eff m. MonadAff ( Effects eff ) m => Component m
+dropdown :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
 dropdown =
   H.parentComponent
     { initialState: const unit
@@ -50,7 +50,7 @@ dropdown =
     render :: Unit -> HTML Dropdown.Query m
     render _ = HH.slot unit Dropdown.component unit absurd
 
-typeahead :: ∀ t eff m. MonadAff ( Effects eff ) m => Component m
+typeahead :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
 typeahead =
   H.parentComponent
     { initialState: const unit
@@ -63,9 +63,19 @@ typeahead =
     eval (NoOp a) = pure a
 
     render :: Unit -> HTML Typeahead.Query m
-    render _ = HH.slot unit Typeahead.component [ "Lyndsey Duffield", "Chris Pine", "Kevin Hart" ] (const Nothing)
+    render _ = HH.slot unit Typeahead.component users (const Nothing)
 
-calendar :: ∀ t eff m. MonadAff ( Effects eff ) m => Component m
+    users :: Array String
+    users =
+      [ "Lyndsey Duffield"
+      , "Chris Pine"
+      , "Kevin Hart"
+      , "Dave Chappelle"
+      , "Hannibal Buress"
+      , "Rico Suave"
+      ]
+
+calendar :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
 calendar =
   H.parentComponent
     { initialState: const unit

--- a/docs/src/Components/Calendar/Calendar.purs
+++ b/docs/src/Components/Calendar/Calendar.purs
@@ -84,6 +84,8 @@ component =
           let showCalendar (CalendarItem _ _ _ d) = show d
           H.liftAff $ log ("Selected! Choice was " <> showCalendar item)
 
+        otherwise -> pure a
+
       ToggleMonth dir a -> a <$ do
         st <- H.get
 

--- a/docs/src/Components/Dropdown/Dropdown.purs
+++ b/docs/src/Components/Dropdown/Dropdown.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Monad.Aff.Class (class MonadAff)
 import Control.Monad.Aff.Console (log, logShow, CONSOLE)
 import DOM (DOM)
-import Data.Array ((:), difference, mapWithIndex, length, delete)
+import Data.Array (mapWithIndex)
 import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
@@ -17,7 +17,7 @@ type DropdownItem = String
 
 type State =
   { items    :: Array DropdownItem
-  , selected :: Array DropdownItem }
+  , selected :: Maybe DropdownItem }
 
 data Query a
   = Log String a
@@ -39,7 +39,7 @@ component =
     }
   where
     initState :: State
-    initState = { items: testData, selected: [] }
+    initState = { items: testData, selected: Nothing }
 
     render
       :: State
@@ -82,29 +82,24 @@ component =
 
         C.ItemSelected item -> do
           H.liftAff $ log ("Selected: " <> item)
-          H.modify \st -> st { selected = ( item : st.selected ) }
+          H.modify \st -> st { selected = pure item }
 
           st <- H.get
           H.liftAff $ logShow st.selected
-          _  <- H.query unit
-                  $ H.action
-                  $ C.ContainerReceiver
-                  $ { render: renderContainer
-                    , items: difference st.items st.selected }
+          _ <- H.query unit
+                 $ H.action
+                 $ C.SetVisibility C.Off
           pure a
+
+        otherwise -> pure a
 
       Removed item a -> do
         st <- H.get
-        let newSelections = delete item st.selected
-            newItems = difference newSelections st.items
-
-        H.modify (_ { selected = newSelections })
+        H.modify (_ { selected = Nothing })
 
         _  <- H.query unit
                 $ H.action
-                $ C.ContainerReceiver
-                $ { render: renderContainer
-                  , items: newItems }
+                $ C.ReplaceItems st.items
 
         pure a
 
@@ -116,6 +111,7 @@ HELPERS
 
 -}
 
+class_ :: ∀ p i. String -> H.IProp ( "class" :: String | i ) p
 class_ = HP.class_ <<< HH.ClassName
 
 -- The parent must provide some input data.
@@ -195,26 +191,24 @@ renderContainer st =
                else "" ]
 
 
-renderSelections items =
-  if length items == 0
-    then HH.div_ []
-    else
-    HH.div
+renderSelections
+  :: ∀ p
+   . Maybe DropdownItem
+  -> H.HTML p Query
+renderSelections Nothing =
+  HH.div_ []
+renderSelections (Just item) =
+  HH.div
     [ class_ "bg-white rounded-sm w-full border-b border-grey-lighter" ]
     [ HH.ul
       [ class_ "list-reset" ]
-      ( renderSelectedItem <$> items )
-    ]
-  where
-    renderSelectedItem item =
-      HH.li
-      [ class_ "px-4 py-1 text-grey-darkest hover:bg-grey-lighter relative" ]
-      [ HH.span_ [ HH.text item ]
-      , closeButton item
+      [ HH.li
+        [ class_ "px-4 py-1 text-grey-darkest hover:bg-grey-lighter relative" ]
+        [ HH.span_ [ HH.text item ]
+        , HH.span
+          [ HE.onClick $ HE.input_ (Removed item)
+          , class_ "absolute pin-t pin-b pin-r p-1 mx-3 cursor-pointer" ]
+          [ HH.text "×" ]
+        ]
       ]
-
-    closeButton item =
-      HH.span
-      [ HE.onClick $ HE.input_ (Removed item)
-      , class_ "absolute pin-t pin-b pin-r p-1 mx-3 cursor-pointer" ]
-        [ HH.text "×" ]
+    ]

--- a/docs/src/Components/Typeahead/Typeahead.purs
+++ b/docs/src/Components/Typeahead/Typeahead.purs
@@ -80,19 +80,12 @@ component =
         SC.SearchMessage m' -> case m' of
           S.NewSearch s -> do
             st <- H.get
-
             let filtered  = filterItems s st.items
                 available = difference filtered st.selected
-
-            _ <- H.query unit
-                  $ H.action
-                  $ SC.ToContainer
-                  $ H.action
-                  $ C.ReplaceItems available
-
+            _ <- H.query unit <<< SC.inContainer $ C.ReplaceItems available
             pure a
 
-          _ -> pure a
+          otherwise -> pure a
 
         SC.ContainerMessage m' -> case m' of
           C.ItemSelected item -> do
@@ -104,15 +97,11 @@ component =
                     , selected = ( item : st.selected ) }
 
             newSt <- H.get
-            _  <- H.query unit
-                    $ H.action
-                    $ SC.ToContainer
-                    $ H.action
-                    $ C.ReplaceItems
-                    $ difference newSt.items newSt.selected
+            let newItems = difference newSt.items newSt.selected
+            _  <- H.query unit <<< SC.inContainer $ C.ReplaceItems newItems
             pure a
 
-          _ -> pure a
+          otherwise -> pure a
 
 
       Removed item a -> do
@@ -120,12 +109,8 @@ component =
         H.modify _ { selected = filter ((/=) item) st.selected }
 
         newSt <- H.get
-        _  <- H.query unit
-                $ H.action
-                $ SC.ToContainer
-                $ H.action
-                $ C.ReplaceItems (difference newSt.items newSt.selected)
-
+        let newItems = difference newSt.items newSt.selected
+        _  <- H.query unit <<< SC.inContainer $ C.ReplaceItems newItems
         pure a
 
 

--- a/docs/src/Components/Typeahead/Typeahead.purs
+++ b/docs/src/Components/Typeahead/Typeahead.purs
@@ -129,6 +129,7 @@ Config
 
 -}
 
+class_ :: ∀ p i. String -> H.IProp ( "class" :: String | i ) p
 class_ = HP.class_ <<< HH.ClassName
 
 renderSearch :: ∀ e
@@ -175,6 +176,10 @@ renderContainer st =
                else "" ]
 
 
+renderSelections
+  :: ∀ p
+   . Array TypeaheadItem
+  -> H.HTML p Query
 renderSelections items =
   if length items == 0
     then HH.div_ []

--- a/docs/src/Components/Typeahead/Typeahead.purs
+++ b/docs/src/Components/Typeahead/Typeahead.purs
@@ -37,7 +37,7 @@ type Input = Array String
 data Message = Void
 
 type ChildSlot = Unit
-type ChildQuery eff = SC.SearchContainerQuery Query TypeaheadItem eff
+type ChildQuery eff m = SC.SearchContainerQuery Query TypeaheadItem eff m
 
 component :: ∀ m e
   . MonadAff ( Effects e ) m
@@ -53,7 +53,9 @@ component =
     initialState :: Input -> State
     initialState i = { items: i, selected: [] }
 
-    render :: State -> H.ParentHTML Query (ChildQuery (Effects e)) ChildSlot m
+    render
+      :: State
+      -> H.ParentHTML Query (ChildQuery (Effects e) m) ChildSlot m
     render st =
       HH.div
         [ class_ "w-full" ]
@@ -67,9 +69,15 @@ component =
           , items: difference st.items st.selected
           , renderSearch
           , renderContainer
+          , render:
+            \search container -> HH.div
+              [ HP.class_ $ HH.ClassName "flex-auto" ]
+              [ search, container ]
           }
 
-    eval :: Query ~> H.ParentDSL State Query (ChildQuery (Effects e)) ChildSlot Message m
+    eval
+      :: Query
+      ~> H.ParentDSL State Query (ChildQuery (Effects e) m) ChildSlot Message m
     eval = case _ of
       Log str a -> a <$ do
         H.liftAff $ log str

--- a/docs/src/Components/Typeahead/Typeahead.purs
+++ b/docs/src/Components/Typeahead/Typeahead.purs
@@ -2,9 +2,8 @@ module Docs.Components.Typeahead where
 
 import Prelude
 
-import Control.Monad.Eff.Timer (setTimeout, TIMER)
 import Control.Monad.Aff.Class (class MonadAff)
-import Control.Monad.Aff.Console (log, logShow, CONSOLE)
+import Control.Monad.Aff.Console (CONSOLE, log)
 import Control.Monad.Aff.AVar (AVAR)
 import DOM (DOM)
 import Data.Array (mapWithIndex, difference, filter, (:))
@@ -12,38 +11,33 @@ import Data.Foldable (length)
 import Data.Maybe (Maybe(..))
 import Data.String (Pattern(..), contains)
 import Data.Time.Duration (Milliseconds(..))
-import Data.Either.Nested (Either2)
-import Data.Functor.Coproduct.Nested (Coproduct2)
-import Halogen.Component.ChildPath as CP
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 
+import Select.Primitives.SearchContainer as SC
 import Select.Primitives.Container as C
 import Select.Primitives.Search as S
 
 type TypeaheadItem = String
-type Effects eff = ( timer :: TIMER, avar :: AVAR, dom :: DOM, console :: CONSOLE | eff )
+
+type Effects eff = ( avar :: AVAR, dom :: DOM, console :: CONSOLE | eff )
 
 data Query a
   = Log String a
-  | HandleContainer (C.Message Query TypeaheadItem) a
-  | HandleSearch    (S.Message Query TypeaheadItem) a
+  | HandleSearchContainer (SC.Message Query TypeaheadItem) a
   | Removed TypeaheadItem a
-
-type ChildSlot = Either2 Unit Unit
-type ChildQuery e
-  = Coproduct2 (C.ContainerQuery Query TypeaheadItem)
-               (S.SearchQuery Query TypeaheadItem (Effects e))
 
 type State =
   { items    :: Array TypeaheadItem
   , selected :: Array TypeaheadItem }
 
 type Input = Array String
-
 data Message = Void
+
+type ChildSlot = Unit
+type ChildQuery eff = SC.SearchContainerQuery Query TypeaheadItem eff
 
 component :: ∀ m e
   . MonadAff ( Effects e ) m
@@ -59,92 +53,80 @@ component =
     initialState :: Input -> State
     initialState i = { items: i, selected: [] }
 
-    render :: State -> H.ParentHTML Query (ChildQuery e) ChildSlot m
+    render :: State -> H.ParentHTML Query (ChildQuery (Effects e)) ChildSlot m
     render st =
       HH.div
         [ class_ "w-full" ]
         [ renderSelections st.selected
-        , HH.slot'
-            CP.cp2
-            unit
-            S.component
-            { render: renderSearch, search: Nothing, debounceTime: Milliseconds 300.0 }
-            ( HE.input HandleSearch )
-        , HH.slot'
-            CP.cp1
-            unit
-            C.component
-            { render: renderContainer, items: st.items }
-            ( HE.input HandleContainer )
+        , HH.slot unit SC.component searchContainerInput (HE.input HandleSearchContainer)
         ]
+      where
+        searchContainerInput =
+          { search: Nothing
+          , debounceTime: Milliseconds 0.0
+          , items: difference st.items st.selected
+          , renderSearch
+          , renderContainer
+          }
 
-    eval :: Query ~> H.ParentDSL State Query (ChildQuery e) ChildSlot Message m
+    eval :: Query ~> H.ParentDSL State Query (ChildQuery (Effects e)) ChildSlot Message m
     eval = case _ of
       Log str a -> a <$ do
         H.liftAff $ log str
 
-      HandleSearch m a -> case m of
-        S.ContainerQuery q -> do
-          _ <- H.query' CP.cp1 unit q
-          pure a
+      HandleSearchContainer m a -> case m of
+        SC.Emit q -> eval q *> pure a
 
-        S.Emit q -> eval q *> pure a
+        SC.SearchMessage m' -> case m' of
+          S.NewSearch s -> do
+            st <- H.get
 
-        -- A new search is done: filter the results!
-        S.NewSearch s -> a <$ do
-          st <- H.get
+            let filtered  = filterItems s st.items
+                available = difference filtered st.selected
 
-          H.liftAff $ log $ "New search performed: " <> s
-
-          let filtered  = filterItems s st.items
-          let available = difference filtered st.selected
-
-          -- Allow insertion of elements
-          let newItems
-                | length available < 1 = s : available
-                | otherwise            = available
-
-          _ <- H.query' CP.cp1 unit
-                 $ H.action
-                 $ C.ContainerReceiver { render: renderContainer, items: newItems }
-
-          -- Test custom effects
-          _ <- H.liftEff $ setTimeout 100 (pure unit)
-          pure a
-
-
-      HandleContainer m a -> case m of
-        C.Emit q -> eval q *> pure a
-
-        C.ItemSelected item -> a <$ do
-          st <- H.get
-          if length (filter ((==) item) st.items) > 0
-            then H.modify _ { selected = ( item : st.selected ) }
-            else H.modify _
-                  { items = ( item : st.items )
-                  , selected = ( item : st.selected ) }
-
-          newSt <- H.get
-          _  <- H.query' CP.cp1 unit
+            _ <- H.query unit
                   $ H.action
-                  $ C.ContainerReceiver
-                  $ { render: renderContainer
-                    , items: difference newSt.items newSt.selected }
+                  $ SC.ToContainer
+                  $ H.action
+                  $ C.ReplaceItems available
 
-          H.liftAff $ log "List of selections..." *> logShow newSt.selected
+            pure a
 
-      Removed item a -> a <$ do
+          _ -> pure a
+
+        SC.ContainerMessage m' -> case m' of
+          C.ItemSelected item -> do
+            st <- H.get
+            if length (filter ((==) item) st.items) > 0
+              then H.modify _ { selected = ( item : st.selected ) }
+              else H.modify _
+                    { items = ( item : st.items )
+                    , selected = ( item : st.selected ) }
+
+            newSt <- H.get
+            _  <- H.query unit
+                    $ H.action
+                    $ SC.ToContainer
+                    $ H.action
+                    $ C.ReplaceItems
+                    $ difference newSt.items newSt.selected
+            pure a
+
+          _ -> pure a
+
+
+      Removed item a -> do
         st <- H.get
         H.modify _ { selected = filter ((/=) item) st.selected }
 
         newSt <- H.get
-        _  <- H.query' CP.cp1 unit
+        _  <- H.query unit
                 $ H.action
-                $ C.ContainerReceiver
-                $ { render: renderContainer
-                  , items: difference newSt.items newSt.selected }
+                $ SC.ToContainer
+                $ H.action
+                $ C.ReplaceItems (difference newSt.items newSt.selected)
 
-        H.liftAff $ log "List of selections..." *> logShow newSt.selected
+        pure a
 
 
 {-

--- a/src/Primitives/SearchContainer.purs
+++ b/src/Primitives/SearchContainer.purs
@@ -1,0 +1,140 @@
+module Select.Primitives.SearchContainer where
+
+import Prelude
+
+import Control.Comonad (extract)
+import Control.Comonad.Store (Store, store)
+import Control.Monad.Aff.AVar (AVAR)
+import Control.Monad.Aff.Class (class MonadAff)
+import DOM (DOM)
+import Data.Either.Nested (Either2)
+import Data.Functor.Coproduct.Nested (Coproduct2)
+import Data.Maybe (Maybe)
+import Data.Time.Duration (Milliseconds)
+import Halogen as H
+import Halogen.Component.ChildPath (cp1, cp2) as CP
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Select.Primitives.Container as C
+import Select.Primitives.Search as S
+
+data SearchContainerQuery o item eff a
+  = ToSearch (S.SearchQuery o item eff Unit) a
+  | ToContainer (C.ContainerQuery o item Unit) a
+  | HandleSearch (S.Message o item) a
+  | HandleContainer (C.Message o item) a
+  | Receiver (Input o item eff) a
+
+type State = Unit
+
+type Input o item eff =
+  { items :: Array item
+  , search :: Maybe String
+  , debounceTime :: Milliseconds
+  , renderSearch :: S.SearchState eff -> H.ComponentHTML (S.SearchQuery o item eff)
+  , renderContainer :: C.ContainerState item -> H.ComponentHTML (C.ContainerQuery o item)
+  }
+
+data Message o item
+  = ContainerMessage (C.Message o item)
+  | SearchMessage (S.Message o item)
+  | Emit (o Unit)
+
+type Effects eff = ( dom :: DOM, avar :: AVAR | eff )
+
+type ChildQuery o item eff = Coproduct2
+  (C.ContainerQuery o item)
+  (S.SearchQuery    o item eff)
+type ChildSlot = Either2 Slot Slot
+
+data Slot
+  = ContainerSlot
+  | SearchSlot
+derive instance eqPrimitiveSlot :: Eq Slot
+derive instance ordPrimitiveSlot :: Ord Slot
+
+type StateStore o item eff m =
+  Store
+    State
+    (H.ParentHTML
+      (SearchContainerQuery o item eff)
+      (ChildQuery o item eff)
+      ChildSlot
+      m)
+
+component :: ∀ o item eff m
+  . MonadAff (Effects eff) m
+ => H.Component
+     HH.HTML
+     (SearchContainerQuery o item (Effects eff))
+     (Input o item (Effects eff))
+     (Message o item)
+     m
+component =
+  H.parentComponent
+    { initialState
+    , render: extract
+    , eval
+    , receiver: HE.input Receiver
+    }
+  where
+    initialState
+      :: Input o item (Effects eff)
+      -> StateStore o item (Effects eff) m
+    initialState i = store render' unit
+      where
+        render' _ =
+          HH.div_
+          [ HH.slot' CP.cp2 SearchSlot S.component inputS (HE.input HandleSearch)
+          , HH.slot' CP.cp1 ContainerSlot C.component inputC (HE.input HandleContainer) ]
+
+        inputS =
+          { search: i.search
+          , debounceTime: i.debounceTime
+          , render: i.renderSearch }
+
+        inputC =
+          { items: i.items
+          , render: i.renderContainer }
+
+
+    ----------
+    -- EVAL
+
+    eval
+      :: SearchContainerQuery o item (Effects eff)
+      ~> H.ParentDSL
+          (StateStore o item (Effects eff) m)
+          (SearchContainerQuery o item (Effects eff))
+          (ChildQuery o item (Effects eff))
+          (ChildSlot)
+          (Message o item)
+          m
+
+    -- Route any container queries to the container
+    eval (ToContainer q a) = H.query' CP.cp1 ContainerSlot q *> pure a
+
+    -- Route any search queries to the search input
+    eval (ToSearch q a) = H.query' CP.cp2 SearchSlot q *> pure a
+
+    eval (HandleContainer m a) = case m of
+      C.Emit query -> H.raise (Emit query) *> pure a
+      other -> H.raise (ContainerMessage other) *> pure a
+
+    eval (HandleSearch m a) = case m of
+      S.Emit query -> H.raise (Emit query) *> pure a
+      other -> H.raise (SearchMessage other) *> pure a
+
+    eval (Receiver i a) = do
+      _ <- H.query' CP.cp1 ContainerSlot $ H.action $ C.ContainerReceiver containerInput
+      _ <- H.query' CP.cp2 SearchSlot $ H.action $ S.SearchReceiver searchInput
+      pure a
+      where
+        searchInput =
+          { search: i.search
+          , debounceTime: i.debounceTime
+          , render: i.renderSearch }
+        containerInput =
+          { items: i.items
+          , render: i.renderContainer }
+

--- a/src/Primitives/SearchContainer.purs
+++ b/src/Primitives/SearchContainer.purs
@@ -138,3 +138,15 @@ component =
           { items: i.items
           , render: i.renderContainer }
 
+-----
+-- Helpers
+
+inContainer :: ∀ o item eff
+  . H.Action (C.ContainerQuery o item)
+ -> SearchContainerQuery o item eff Unit
+inContainer = H.action <<< ToContainer <<< H.action
+
+inSearch :: ∀ o item eff
+  . H.Action (S.SearchQuery o item eff)
+ -> SearchContainerQuery o item eff Unit
+inSearch = H.action <<< ToSearch <<< H.action

--- a/src/Primitives/SearchContainer.purs
+++ b/src/Primitives/SearchContainer.purs
@@ -119,10 +119,15 @@ component =
 
     eval (HandleContainer m a) = case m of
       C.Emit query -> H.raise (Emit query) *> pure a
+      C.ContainerClicked -> a <$ do
+         H.query' CP.cp2 SearchSlot $ H.action S.TriggerFocus
       other -> H.raise (ContainerMessage other) *> pure a
 
     eval (HandleSearch m a) = case m of
       S.Emit query -> H.raise (Emit query) *> pure a
+      S.ContainerQuery query -> eval $ ToContainer query a
+      S.Focused -> a <$ do
+         H.query' CP.cp1 ContainerSlot $ H.action $ C.SetVisibility C.On
       other -> H.raise (SearchMessage other) *> pure a
 
     eval (Receiver i a) = do


### PR DESCRIPTION
## What does this pull request do?

This PR makes two-way communication between the primitives easier in preparation for a rewrite into a single component.

## Where should the reviewer start?

Review the changes in SearchContainer, and then review how that affects the Typeahead example

## Other Notes:

This is a band-aid fix to the annoyance of communicating between the Search and Container. For the reasons stated in the commit comments for https://github.com/citizennet/purescript-halogen-select/commit/e9c6586d628c33a17aa923e916b5f02f2fccf962 this is not meant to be a permanent architectural change.