### PR TITLE
SearchContainer focus

### DIFF
--- a/docs/site/config.toml
+++ b/docs/site/config.toml
@@ -1,5 +1,5 @@
 # The base URL pages are relative to
-base_url = "https://citizennet.github.io/purescript-halogen-select"
+base_url = "/purescript-halogen-select/"
 
 # Don't provide or compile from Sass folder
 compile_sass = true

--- a/docs/src/App/Component.purs
+++ b/docs/src/App/Component.purs
@@ -35,7 +35,7 @@ type Effects eff = ( console :: CONSOLE, dom :: DOM, now :: NOW, avar :: AVAR, t
 ----------
 -- Built components
 
-dropdown :: ∀ t eff m. MonadAff ( Effects eff ) m => Component m
+dropdown :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
 dropdown =
   H.parentComponent
     { initialState: const unit
@@ -50,7 +50,7 @@ dropdown =
     render :: Unit -> HTML Dropdown.Query m
     render _ = HH.slot unit Dropdown.component unit absurd
 
-typeahead :: ∀ t eff m. MonadAff ( Effects eff ) m => Component m
+typeahead :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
 typeahead =
   H.parentComponent
     { initialState: const unit
@@ -75,7 +75,7 @@ typeahead =
       , "Rico Suave"
       ]
 
-calendar :: ∀ t eff m. MonadAff ( Effects eff ) m => Component m
+calendar :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
 calendar =
   H.parentComponent
     { initialState: const unit

--- a/docs/src/App/Component.purs
+++ b/docs/src/App/Component.purs
@@ -63,7 +63,17 @@ typeahead =
     eval (NoOp a) = pure a
 
     render :: Unit -> HTML Typeahead.Query m
-    render _ = HH.slot unit Typeahead.component [ "Lyndsey Duffield", "Chris Pine", "Kevin Hart" ] (const Nothing)
+    render _ = HH.slot unit Typeahead.component users (const Nothing)
+
+    users :: Array String
+    users =
+      [ "Lyndsey Duffield"
+      , "Chris Pine"
+      , "Kevin Hart"
+      , "Dave Chappelle"
+      , "Hannibal Buress"
+      , "Rico Suave"
+      ]
 
 calendar :: ∀ t eff m. MonadAff ( Effects eff ) m => Component m
 calendar =

--- a/docs/src/Components/Calendar/Calendar.purs
+++ b/docs/src/Components/Calendar/Calendar.purs
@@ -80,11 +80,11 @@ component =
       HandleContainer m a -> case m of
         C.Emit q -> eval q *> pure a
 
-        C.ContainerClicked -> pure a
-
         C.ItemSelected item -> a <$ do
           let showCalendar (CalendarItem _ _ _ d) = show d
           H.liftAff $ log ("Selected! Choice was " <> showCalendar item)
+
+        otherwise -> pure a
 
       ToggleMonth dir a -> a <$ do
         st <- H.get

--- a/docs/src/Components/Calendar/Calendar.purs
+++ b/docs/src/Components/Calendar/Calendar.purs
@@ -80,6 +80,8 @@ component =
       HandleContainer m a -> case m of
         C.Emit q -> eval q *> pure a
 
+        C.ContainerClicked -> pure a
+
         C.ItemSelected item -> a <$ do
           let showCalendar (CalendarItem _ _ _ d) = show d
           H.liftAff $ log ("Selected! Choice was " <> showCalendar item)

--- a/docs/src/Components/Dropdown/Dropdown.purs
+++ b/docs/src/Components/Dropdown/Dropdown.purs
@@ -80,6 +80,8 @@ component =
       HandleContainer m a -> case m of
         C.Emit q -> eval q *> pure a
 
+        C.ContainerClicked -> pure a
+
         C.ItemSelected item -> do
           H.liftAff $ log ("Selected: " <> item)
           H.modify \st -> st { selected = ( item : st.selected ) }

--- a/docs/src/Components/Dropdown/Dropdown.purs
+++ b/docs/src/Components/Dropdown/Dropdown.purs
@@ -99,9 +99,7 @@ component =
 
         _  <- H.query unit
                 $ H.action
-                $ C.ContainerReceiver
-                $ { render: renderContainer
-                  , items: st.items }
+                $ C.ReplaceItems st.items
 
         pure a
 

--- a/docs/src/Components/Typeahead/Typeahead.purs
+++ b/docs/src/Components/Typeahead/Typeahead.purs
@@ -129,6 +129,7 @@ Config
 
 -}
 
+class_ :: ∀ p i. String -> H.IProp ( "class" :: String | i ) p
 class_ = HP.class_ <<< HH.ClassName
 
 renderSearch :: ∀ e
@@ -175,6 +176,10 @@ renderContainer st =
                else "" ]
 
 
+renderSelections
+  :: ∀ p
+   . Array TypeaheadItem
+  -> H.HTML p Query
 renderSelections items =
   if length items == 0
     then HH.div_ []

--- a/src/Primitives/Container.purs
+++ b/src/Primitives/Container.purs
@@ -226,7 +226,7 @@ component =
         (Tuple _ st) <- getState
         if not st.open || st.mouseDown
           then pure a
-          else a <$ (eval $ SetVisibility Off a)
+          else eval $ SetVisibility Off a
 
       -- When toggling, the user will lose their highlighted index.
       SetVisibility status a -> a <$ do
@@ -416,6 +416,6 @@ getItemProps :: ∀ o item e
 getItemProps index = flip (<>)
   [ HE.onMouseDown $ HE.input_ $ Select index
   , HE.onMouseOver $ HE.input_ $ Highlight (Index index)
-  , HE.onKeyDown   $ HE.input  $ \ev -> Key ev
+  , HE.onKeyDown   $ HE.input  $ Key
   , HE.onBlur      $ HE.input_ $ Blur
   ]

--- a/src/Primitives/Container.purs
+++ b/src/Primitives/Container.purs
@@ -17,6 +17,7 @@ import DOM.Event.KeyboardEvent as KE
 import DOM.Event.Types as ET
 import Data.Array (length, (!!))
 import Data.Maybe (Maybe(..))
+import Data.Traversable (traverse_)
 import Data.Tuple (Tuple(..))
 import Halogen as H
 import Halogen.HTML as HH
@@ -194,19 +195,17 @@ component =
       Key (ev :: KE.KeyboardEvent) a -> do
         (Tuple _ st) <- getState
         if not st.open then pure a else case KE.code ev of
-          "Enter" -> do
+          "Enter" -> a <$ do
             H.liftEff $ preventDefault $ KE.keyboardEventToEvent ev
-            case st.highlightedIndex of
-              Nothing -> pure a
-              Just index -> eval $ Select index a
+            traverse_ (\index -> eval $ Select index a) st.highlightedIndex
 
           "Escape" -> a <$ (H.modify $ seeks _ { open = false })
 
-          "ArrowUp" -> a <$ do
+          "ArrowUp" -> do
             H.liftEff $ preventDefault $ KE.keyboardEventToEvent ev
             eval $ Highlight Prev a
 
-          "ArrowDown" -> a <$ do
+          "ArrowDown" -> do
             H.liftEff $ preventDefault $ KE.keyboardEventToEvent ev
             eval $ Highlight Next a
 

--- a/src/Primitives/Container.purs
+++ b/src/Primitives/Container.purs
@@ -11,7 +11,6 @@ import Prelude
 import Control.Comonad (extract)
 import Control.Comonad.Store (seeks, store)
 import Control.Monad.Aff.Class (class MonadAff)
-import Control.Monad.Aff.Console (CONSOLE, log)
 import DOM (DOM)
 import DOM.Event.Event (preventDefault)
 import DOM.Event.KeyboardEvent as KE
@@ -118,7 +117,7 @@ type ContainerInput o item =
 -- | - `Emit`: A parent query has been triggered and should be evaluated by the parent. Typically:
 -- |
 -- | ```purescript
--- | eval (HandleContainer (Emit q) next) = eval q *> pure next)
+-- | eval (HandleContainer (Emit q) next) = eval q *> pure next
 -- | ```
 data Message o item
   = ItemSelected item
@@ -129,7 +128,7 @@ data Message o item
 -- | The primitive handles state and transformations but defers all rendering to the parent. The
 -- | render function can be written using our helper functions to ensure the right events are included.
 component :: ∀ o item eff m
-  . MonadAff ( dom :: DOM, console :: CONSOLE | eff ) m
+  . MonadAff ( dom :: DOM | eff ) m
  => H.Component HH.HTML (ContainerQuery o item) (ContainerInput o item) (Message o item) m
 component =
   H.component

--- a/src/Primitives/Container.purs
+++ b/src/Primitives/Container.purs
@@ -114,6 +114,8 @@ type ContainerInput o item =
 -- | - `ContainerClicked`: The container has been clicked, which draws focus away from the
 -- |                       search if used with a search primitive, this message lets the search
 -- |                       container know to return focus to it
+-- | - `VisibilitySet`: Notifies the parent that the container visibility has a new value.
+-- |                    Useful when you need to trigger some behavior (like validation) when the user closes or opens the menu.
 -- | - `Emit`: A parent query has been triggered and should be evaluated by the parent. Typically:
 -- |
 -- | ```purescript
@@ -229,10 +231,8 @@ component =
       -- When toggling, the user will lose their highlighted index.
       SetVisibility status a -> a <$ do
         case status of
-          On     -> do
-            H.modify $ seeks (_ { open = true })
-          Off    -> do
-            H.modify $ seeks (_ { open = false, highlightedIndex = Nothing })
+          On  -> H.modify $ seeks (_ { open = true })
+          Off -> H.modify $ seeks (_ { open = false, highlightedIndex = Nothing })
         H.raise $ VisibilitySet status
 
       ToggleVisibility a -> a <$ do

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -269,8 +269,8 @@ getInputProps :: ∀ o item e eff
         (SearchQuery o item eff)
       )
 getInputProps = flip (<>)
-  [ HE.onFocus      $ HE.input  $ \ev -> CaptureFocus ev
-  , HE.onKeyDown    $ HE.input  $ \ev -> FromContainer $ H.action $ C.Key ev
+  [ HE.onFocus      $ HE.input  $ CaptureFocus
+  , HE.onKeyDown    $ HE.input  $ FromContainer <<< H.action <<< C.Key
   , HE.onValueInput $ HE.input  TextInput
   , HE.onBlur       $ HE.input_ $ FromContainer $ H.action $ C.Blur
   , HP.tabIndex 0

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -221,17 +221,18 @@ component =
 
       CaptureFocus e a -> a <$ do
         (Tuple _ st) <- getState
-        let el = either (const Nothing) Just <<< runExcept <<< readHTMLElement <<< toForeign <<< currentTarget <<< focusEventToEvent $ e
-        H.modify $ seeks _ { inputEl = el }
+        let el = either (const Nothing) Just
+                 <<< runExcept
+                 <<< readHTMLElement
+                 <<< toForeign
+                 <<< currentTarget
+                 <<< focusEventToEvent
+        H.modify $ seeks _ { inputEl = el e }
         H.raise Focused
 
-      TriggerFocus a -> do
+      TriggerFocus a -> a <$ do
         (Tuple _ st) <- getState
-        case st.inputEl of
-          Nothing -> pure a
-          Just el -> do
-            _ <- H.liftEff $ focus el
-            pure a
+        traverse_ (H.liftEff <<< focus) st.inputEl
 
 -- | Attach the necessary properties to the input field you render in the page. This
 -- | should be used directly on the input field's list of properties:

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -6,22 +6,34 @@ module Select.Primitives.Search where
 
 import Prelude
 
-import Data.Time.Duration (Milliseconds)
-import DOM.Event.Types as ET
 import Control.Comonad (extract)
 import Control.Comonad.Store (seeks, store)
 import Control.Monad.Aff (Fiber, delay, error, forkAff, killFiber)
 import Control.Monad.Aff.AVar (AVar, makeEmptyVar, putVar, takeVar, AVAR)
 import Control.Monad.Aff.Class (class MonadAff)
+import Control.Monad.Aff.Console (CONSOLE)
+import Control.Monad.Except (runExcept)
+import DOM (DOM)
+import DOM.Event.Event (currentTarget)
+import DOM.Event.FocusEvent (focusEventToEvent)
+import DOM.Event.FocusEvent as FE
+import DOM.Event.Types as ET
+import DOM.HTML.HTMLElement (focus)
+import DOM.HTML.Types (HTMLElement, readHTMLElement)
+import Data.Either (either)
+import Data.Foreign (toForeign)
 import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Time.Duration (Milliseconds)
 import Data.Tuple (Tuple(..))
-import Halogen (IProp, Component, ComponentDSL, ComponentHTML, action, component, liftAff, modify) as H
+import Halogen (IProp, Component, ComponentDSL, ComponentHTML, action, component, liftAff, modify, liftEff) as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.Query.HalogenM (fork, raise) as H
-import Select.Primitives.State (State, updateStore, getState)
 import Select.Primitives.Container as C
+import Select.Primitives.State (State, updateStore, getState)
+
+type Effects eff = ( avar :: AVAR, console :: CONSOLE, dom :: DOM | eff )
 
 -- | The query type for the `Search` primitive. This primitive handles text input
 -- | and debouncing. It has a special query for the purpose of embedding Container
@@ -46,11 +58,15 @@ import Select.Primitives.Container as C
 -- | - `Raise`: Embed a parent query that can be returned to the parent for evaluation
 -- | - `FromContainer`: Embed a container query that can be routed to a container slot
 -- | - `SearchReceiver`: Update the component with new `Input` when the parent re-renders
+-- | - `CaptureFocus`: TODO
+-- | - `TriggerFocus`: TODO
 data SearchQuery o item eff a
   = TextInput String a
   | Raise (o Unit) a
   | FromContainer (C.ContainerQuery o item Unit) a
   | SearchReceiver (SearchInput o item eff) a
+  | CaptureFocus FE.FocusEvent a
+  | TriggerFocus a
 
 -- | The `Search` primitive internal state.
 -- |
@@ -70,6 +86,7 @@ type SearchState eff =
   { search    :: String
   , ms        :: Milliseconds
   , debouncer :: Maybe (Debouncer eff)
+  , inputEl   :: Maybe HTMLElement
   }
 
 -- | The `Debouncer` type alias, used to debounce user input in the `Search` primitive.
@@ -119,11 +136,11 @@ data Message o item
 -- | The primitive handles state and transformations but defers all rendering to the parent. The
 -- | render function can be written using our helper functions to ensure the right events are included.
 component :: ∀ o item eff m
-  . MonadAff (avar :: AVAR | eff) m
+  . MonadAff (Effects eff) m
  => H.Component
      HH.HTML
-     (SearchQuery o item (avar :: AVAR | eff))
-     (SearchInput o item (avar :: AVAR | eff))
+     (SearchQuery o item (Effects eff))
+     (SearchInput o item (Effects eff))
      (Message o item)
      m
 component =
@@ -135,23 +152,24 @@ component =
     }
   where
     initialState
-      :: SearchInput o item (avar :: AVAR | eff)
+      :: SearchInput o item (Effects eff)
       -> State
-          (SearchState (avar :: AVAR | eff))
-          (SearchQuery o item (avar :: AVAR | eff))
+          (SearchState (Effects eff))
+          (SearchQuery o item (Effects eff))
     initialState i = store i.render
       { search: fromMaybe "" i.search
       , ms: i.debounceTime
       , debouncer: Nothing
+      , inputEl: Nothing
       }
 
     eval
-      :: (SearchQuery o item (avar :: AVAR | eff))
+      :: (SearchQuery o item (Effects eff))
       ~> H.ComponentDSL
           (State
-            (SearchState (avar :: AVAR | eff))
-            (SearchQuery o item (avar :: AVAR | eff)))
-          (SearchQuery o item (avar :: AVAR | eff))
+            (SearchState (Effects eff))
+            (SearchQuery o item (Effects eff)))
+          (SearchQuery o item (Effects eff))
           (Message o item)
           m
     eval = case _ of
@@ -198,6 +216,18 @@ component =
       -- the parent to set the text.
       SearchReceiver i a -> H.modify (updateStore i.render id) *> pure a
 
+      CaptureFocus e a -> a <$ do
+        (Tuple _ st) <- getState
+        let el = either (const Nothing) Just <<< runExcept <<< readHTMLElement <<< toForeign <<< currentTarget <<< focusEventToEvent $ e
+        H.modify $ seeks _ { inputEl = el }
+
+      TriggerFocus a -> do
+        (Tuple _ st) <- getState
+        case st.inputEl of
+          Nothing -> pure a
+          Just el -> do
+            _ <- H.liftEff $ focus el
+            pure a
 
 -- | Attach the necessary properties to the input field you render in the page. This
 -- | should be used directly on the input field's list of properties:
@@ -237,7 +267,8 @@ getInputProps :: ∀ o item e eff
         (SearchQuery o item eff)
       )
 getInputProps = flip (<>)
-  [ HE.onFocus      $ HE.input_ $ FromContainer $ H.action $ C.Visibility C.Toggle
+  -- [ HE.onFocus      $ HE.input_ $ FromContainer $ H.action $ C.Visibility C.Toggle
+  [ HE.onFocus      $ HE.input  $ \ev -> CaptureFocus ev
   , HE.onKeyDown    $ HE.input  $ \ev -> FromContainer $ H.action $ C.Key ev
   , HE.onValueInput $ HE.input  TextInput
   , HE.onMouseDown  $ HE.input_ $ FromContainer $ H.action $ C.Mouse C.Down

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -11,7 +11,6 @@ import Control.Comonad.Store (seeks, store)
 import Control.Monad.Aff (Fiber, delay, error, forkAff, killFiber)
 import Control.Monad.Aff.AVar (AVar, makeEmptyVar, putVar, takeVar, AVAR)
 import Control.Monad.Aff.Class (class MonadAff)
-import Control.Monad.Aff.Console (CONSOLE)
 import Control.Monad.Except (runExcept)
 import DOM (DOM)
 import DOM.Event.Event (currentTarget)
@@ -33,7 +32,7 @@ import Halogen.Query.HalogenM (fork, raise) as H
 import Select.Primitives.Container as C
 import Select.Primitives.State (State, updateStore, getState)
 
-type Effects eff = ( avar :: AVAR, console :: CONSOLE, dom :: DOM | eff )
+type Effects eff = ( avar :: AVAR, dom :: DOM | eff )
 
 -- | The query type for the `Search` primitive. This primitive handles text input
 -- | and debouncing. It has a special query for the purpose of embedding Container
@@ -54,12 +53,12 @@ type Effects eff = ( avar :: AVAR, console :: CONSOLE, dom :: DOM | eff )
 -- |
 -- | Constructors:
 -- |
--- | - `TextInput`: Handle new text input as a string
--- | - `Raise`: Embed a parent query that can be returned to the parent for evaluation
--- | - `FromContainer`: Embed a container query that can be routed to a container slot
--- | - `SearchReceiver`: Update the component with new `Input` when the parent re-renders
--- | - `CaptureFocus`: TODO
--- | - `TriggerFocus`: TODO
+-- | - `TextInput`: Handle new text input as a string.
+-- | - `Raise`: Embed a parent query that can be returned to the parent for evaluation.
+-- | - `FromContainer`: Embed a container query that can be routed to a container slot.
+-- | - `SearchReceiver`: Update the component with new `Input` when the parent re-renders.
+-- | - `CaptureFocus`: Capture input element from focus event.
+-- | - `TriggerFocus`: Refocus input element.
 data SearchQuery o item eff a
   = TextInput String a
   | Raise (o Unit) a
@@ -82,6 +81,7 @@ data SearchQuery o item eff a
 -- | - `ms`: Number of milliseconds for the input to be debounced before passing
 -- |         a message to the parent. Set to 0.0 if you don't want debouncing.
 -- | - `debouncer`: Facilitates debouncing for the input field.
+-- | - `inputEl`: Reference to search element so we can manually trigger focus./
 type SearchState eff =
   { search    :: String
   , ms        :: Milliseconds
@@ -120,6 +120,8 @@ type SearchInput o item eff =
 -- | ```purescript
 -- | eval (FromContainer q a) -> H.raise (ContainerQuery q) *> pure a
 -- | ```
+-- |
+-- | - `Focused`: The search input element has been focused on.
 -- |
 -- | - `Emit`: An embedded parent query has been triggered. This can be evaluated automatically
 -- |           with this code in the parent's eval function:

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -19,10 +19,11 @@ import DOM.Event.FocusEvent as FE
 import DOM.Event.Types as ET
 import DOM.HTML.HTMLElement (focus)
 import DOM.HTML.Types (HTMLElement, readHTMLElement)
-import Data.Either (either)
+import Data.Either (hush)
 import Data.Foreign (toForeign)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Milliseconds)
+import Data.Traversable (traverse_)
 import Data.Tuple (Tuple(..))
 import Halogen (IProp, Component, ComponentDSL, ComponentHTML, action, component, liftAff, modify, liftEff) as H
 import Halogen.HTML as HH
@@ -221,12 +222,12 @@ component =
 
       CaptureFocus e a -> a <$ do
         (Tuple _ st) <- getState
-        let el = either (const Nothing) Just
-                 <<< runExcept
-                 <<< readHTMLElement
-                 <<< toForeign
-                 <<< currentTarget
-                 <<< focusEventToEvent
+        let el = hush
+             <<< runExcept
+             <<< readHTMLElement
+             <<< toForeign
+             <<< currentTarget
+             <<< focusEventToEvent
         H.modify $ seeks _ { inputEl = el e }
         H.raise Focused
 

--- a/src/Primitives/Search.purs
+++ b/src/Primitives/Search.purs
@@ -130,6 +130,7 @@ type SearchInput o item eff =
 data Message o item
   = NewSearch String
   | ContainerQuery (C.ContainerQuery o item Unit)
+  | Focused
   | Emit (o Unit)
 
 
@@ -220,6 +221,7 @@ component =
         (Tuple _ st) <- getState
         let el = either (const Nothing) Just <<< runExcept <<< readHTMLElement <<< toForeign <<< currentTarget <<< focusEventToEvent $ e
         H.modify $ seeks _ { inputEl = el }
+        H.raise Focused
 
       TriggerFocus a -> do
         (Tuple _ st) <- getState
@@ -244,8 +246,6 @@ getInputProps :: ∀ o item e eff
         , onKeyDown :: ET.KeyboardEvent
         , onInput :: ET.Event
         , value :: String
-        , onMouseDown :: ET.MouseEvent
-        , onMouseUp :: ET.MouseEvent
         , onBlur :: ET.FocusEvent
         , tabIndex :: Int
         | e
@@ -258,8 +258,6 @@ getInputProps :: ∀ o item e eff
         , onKeyDown :: ET.KeyboardEvent
         , onInput :: ET.Event
         , value :: String
-        , onMouseDown :: ET.MouseEvent
-        , onMouseUp :: ET.MouseEvent
         , onBlur :: ET.FocusEvent
         , tabIndex :: Int
         | e
@@ -267,12 +265,9 @@ getInputProps :: ∀ o item e eff
         (SearchQuery o item eff)
       )
 getInputProps = flip (<>)
-  -- [ HE.onFocus      $ HE.input_ $ FromContainer $ H.action $ C.Visibility C.Toggle
   [ HE.onFocus      $ HE.input  $ \ev -> CaptureFocus ev
   , HE.onKeyDown    $ HE.input  $ \ev -> FromContainer $ H.action $ C.Key ev
   , HE.onValueInput $ HE.input  TextInput
-  , HE.onMouseDown  $ HE.input_ $ FromContainer $ H.action $ C.Mouse C.Down
-  , HE.onMouseUp    $ HE.input_ $ FromContainer $ H.action $ C.Mouse C.Up
   , HE.onBlur       $ HE.input_ $ FromContainer $ H.action $ C.Blur
   , HP.tabIndex 0
   ]

--- a/src/Primitives/SearchContainer.purs
+++ b/src/Primitives/SearchContainer.purs
@@ -128,7 +128,7 @@ component =
       S.Emit query -> H.raise (Emit query) *> pure a
       S.ContainerQuery query -> eval $ ToContainer query a
       S.Focused -> a <$ do
-         H.query' CP.cp1 ContainerSlot $ H.action $ C.Visibility C.On
+         H.query' CP.cp1 ContainerSlot $ H.action $ C.SetVisibility C.On
       other -> H.raise (SearchMessage other) *> pure a
 
     eval (Receiver i a) = do

--- a/src/Primitives/SearchContainer.purs
+++ b/src/Primitives/SearchContainer.purs
@@ -6,7 +6,6 @@ import Control.Comonad (extract)
 import Control.Comonad.Store (Store, store)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Aff.Class (class MonadAff)
-import Control.Monad.Eff.Console (CONSOLE)
 import DOM (DOM)
 import Data.Either.Nested (Either2)
 import Data.Functor.Coproduct.Nested (Coproduct2)
@@ -41,7 +40,7 @@ data Message o item
   | SearchMessage (S.Message o item)
   | Emit (o Unit)
 
-type Effects eff = ( dom :: DOM, avar :: AVAR, console :: CONSOLE | eff )
+type Effects eff = ( dom :: DOM, avar :: AVAR | eff )
 
 type ChildQuery o item eff = Coproduct2
   (C.ContainerQuery o item)


### PR DESCRIPTION
## What does this pull request do?

This PR fixes focus and blur behavior for the search primitive. It also updates some of the queries to make more sense and exposes more messages to the parent. Specifically, when the container is clicked on (usually because an item has been selected, but the click could come from anywhere inside the container), it sends a message to the parent so that it can re-trigger focus on the search input. Also when the container visibility is set, it sends a message to the parent so that it can do things like trigger validation.

## Where should the reviewer start?

Start with the primitives, then see how those changes affect the docs components.

## Other Notes:

Project documentation need to be updated. Specifically the markdown tutorials are out of sync with how the docs components are implemented.