### PR TITLE
Update `setToggleProps` to properly trigger focus and toggle on/off on click

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "purescript-control": "^3.3.1",
     "purescript-transformers": "^3.5.0",
     "purescript-dom": "^4.15.0",
-    "purescript-aff": "^4.0.0"
+    "purescript-aff": "^4.0.0",
+    "purescript-day": "^9.1.0"
   },
   "devDependencies": {
     "purescript-dom-classy": "^2.1.0",

--- a/docs/site/content/_index.md
+++ b/docs/site/content/_index.md
@@ -6,6 +6,12 @@ template = "home.html"
 
 ## Typeaheads
 
-Support asynchronous, continuously asynchronous, and synchronous typeaheads with autocompletion.
+Use input-driven selects to support typeaheads and autocompletion.
 
 {{ halogen(id="typeahead", header="Typeahead") }}
+
+## Dropdowns
+
+Use toggle-driven selects to support dropdowns.
+
+{{ halogen(id="dropdown", header="Dropdown") }}

--- a/docs/src/App/Component.purs
+++ b/docs/src/App/Component.purs
@@ -11,9 +11,11 @@ import Control.Monad.Eff.Now (NOW)
 import Control.Monad.Eff.Timer (TIMER)
 import DOM (DOM)
 import Data.Maybe (Maybe(..))
-import Docs.Components.Typeahead as Typeahead
 import Halogen as H
 import Halogen.HTML as HH
+
+import Docs.Components.Typeahead as Typeahead
+import Docs.Components.Dropdown as Dropdown
 
 ----------
 -- Component Types
@@ -47,6 +49,31 @@ typeahead =
 
     render :: Unit -> HTML Typeahead.Query m
     render _ = HH.slot unit Typeahead.component { items: users, keepOpen: false } (const Nothing)
+
+    users :: Array String
+    users =
+      [ "Lyndsey Duffield"
+      , "Chris Pine"
+      , "Kevin Hart"
+      , "Dave Chappelle"
+      , "Hannibal Buress"
+      , "Rico Suave"
+      ]
+
+dropdown :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
+dropdown =
+  H.parentComponent
+    { initialState: const unit
+    , render
+    , eval
+    , receiver: const Nothing
+    }
+  where
+    eval :: Query ~> DSL Dropdown.Query m
+    eval (NoOp a) = pure a
+
+    render :: Unit -> HTML Dropdown.Query m
+    render _ = HH.slot unit Dropdown.component { items: users } (const Nothing)
 
     users :: Array String
     users =

--- a/docs/src/Components/Dropdown/Dropdown.purs
+++ b/docs/src/Components/Dropdown/Dropdown.purs
@@ -1,0 +1,105 @@
+module Docs.Components.Dropdown where
+
+import Prelude
+
+import Control.Monad.Aff.Class (class MonadAff)
+import Control.Monad.Aff.Console (CONSOLE)
+import Control.Monad.Aff.AVar (AVAR)
+import DOM (DOM)
+import Data.Array (difference, mapWithIndex)
+import Data.Maybe (Maybe(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Select.Utils.Setters as Setters
+import Select as Select
+
+type Effects eff = ( avar :: AVAR, dom :: DOM, console :: CONSOLE | eff )
+type State = { items :: Array String, text :: String }
+type Input = { items :: Array String }
+data Query a = HandleSelect (Select.Message Query String) a
+data Message = Void
+
+type ChildSlot = Unit
+type ChildQuery eff = Select.Query Query String eff
+
+component :: ∀ m e
+  . MonadAff ( Effects e ) m
+ => H.Component HH.HTML Query Input Message m
+component =
+  H.parentComponent
+    { initialState
+    , render
+    , eval
+    , receiver: const Nothing
+    }
+  where
+    initialState :: Input -> State
+    initialState i = { items: i.items, text: "Select an option" }
+
+    eval
+      :: Query
+      ~> H.ParentDSL State Query (ChildQuery (Effects e)) ChildSlot Message m
+    eval = case _ of
+      HandleSelect (Select.Selected item) a -> do
+        st <- H.get
+        _ <- H.query unit $ H.action $ Select.SetVisibility Select.Off
+        _ <- H.query unit $ H.action $ Select.ReplaceItems (difference st.items [ item ])
+        H.modify _ { text = item }
+        pure a
+
+      HandleSelect other a -> pure a
+
+    render
+      :: State
+      -> H.ParentHTML Query (ChildQuery (Effects e)) ChildSlot m
+    render st =
+      HH.div
+        [ class_ "w-full" ]
+        [ HH.slot unit Select.component input (HE.input HandleSelect) ]
+      where
+        input =
+          { initialSearch: Nothing
+          , debounceTime: Nothing
+          , inputType: Select.Toggle
+          , items: difference st.items [ st.text ]
+          , render: renderDropdown
+          }
+
+        class_ :: ∀ p i. String -> H.IProp ( "class" :: String | i ) p
+        class_ = HP.class_ <<< HH.ClassName
+
+        renderDropdown :: Select.State String (Effects e) -> Select.ComponentHTML Query String (Effects e)
+        renderDropdown state = HH.div_ [ renderToggle, renderContainer ]
+          where
+            renderToggle =
+              HH.button
+                ( Setters.setToggleProps props )
+                [ HH.text st.text ]
+                where
+                  props = [ class_ "bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded-sm w-full flex" ]
+
+            renderContainer =
+              HH.div [ class_ "relative z-50" ]
+              $ if state.visibility == Select.Off
+                then []
+                else [ renderItems $ renderItem `mapWithIndex` state.items ]
+              where
+                renderItems html =
+                  HH.div
+                    ( Setters.setContainerProps props )
+                    [ HH.ul [ class_ "list-reset" ] html ]
+                  where
+                    props = [ class_ "absolute bg-white shadow rounded-sm pin-t pin-l w-full" ]
+
+                renderItem index item =
+                  HH.li
+                    ( Setters.setItemProps index props )
+                    [ HH.text item ]
+                  where
+                    props = [ class_
+                      $ "px-4 py-1 text-grey-darkest"
+                      <> if state.highlightedIndex == Just index then " bg-grey-lighter" else ""
+                      ]
+

--- a/docs/src/Main.purs
+++ b/docs/src/Main.purs
@@ -48,7 +48,8 @@ type Components m = Map.Map String (H.Component HH.HTML ComponentQuery Unit Void
 
 routes :: ∀ eff m. MonadAff ( Component.Effects eff ) m => Components m
 routes = Map.fromFoldable
-  [ Tuple "typeahead" $ proxy Component.typeahead ]
+  [ Tuple "typeahead" $ proxy Component.typeahead
+  , Tuple "dropdown" $ proxy Component.dropdown ]
 
 data Query a = NoOp a
 

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -2,6 +2,7 @@ module Select where
 
 import Prelude
 
+import Debug.Trace (spy)
 import Control.Comonad (extract)
 import Control.Comonad.Store (Store, seeks, store)
 import Control.Monad.Aff (Fiber, delay, error, forkAff, killFiber)
@@ -192,12 +193,12 @@ component =
               <<< readHTMLElement
               <<< toForeign
               <<< currentTarget
-        H.modify $ seeks _ { inputElement = elementFromEvent event }
+        H.modify $ seeks _ { inputElement = spy $ elementFromEvent event }
         traverse_ eval query
 
       TriggerFocus a -> a <$ do
         (Tuple _ st) <- getState
-        traverse_ (H.liftEff <<< focus) st.inputElement
+        traverse_ (H.liftEff <<< focus) (spy st.inputElement)
 
       Key ev a -> do
         _ <- eval $ SetVisibility On a
@@ -230,6 +231,7 @@ component =
 
       ToggleVisibility a -> a <$ do
         (Tuple _ st) <- getState
+        _ <- pure $ spy "Visibility toggled"
         case st.visibility of
           Off -> eval $ SetVisibility On a
           On  -> eval $ SetVisibility Off a

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -54,7 +54,7 @@ data Query o item eff a
   = Search String a
   | Highlight Target a
   | Select Int a
-  | CaptureFocus ET.Event a
+  | CaptureRef ET.Event a
   | TriggerFocus a
   | Key KE.KeyboardEvent a
   | PreventClick ME.MouseEvent a
@@ -193,7 +193,7 @@ component =
           Just item -> H.raise (Selected item) *> pure a
           _ -> pure a -- Should not be possible.
 
-      CaptureFocus event a -> a <$ do
+      CaptureRef event a -> a <$ do
         (Tuple _ st) <- getState
         let elementFromEvent
               = hush

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -2,7 +2,6 @@ module Select where
 
 import Prelude
 
-import Debug.Trace (spy)
 import Control.Comonad (extract)
 import Control.Comonad.Store (Store, seeks, store)
 import Control.Monad.Aff (Fiber, delay, error, forkAff, killFiber)
@@ -202,12 +201,12 @@ component =
               <<< readHTMLElement
               <<< toForeign
               <<< currentTarget
-        H.modify $ seeks _ { inputElement = spy $ elementFromEvent event }
+        H.modify $ seeks _ { inputElement = elementFromEvent event }
         pure a
 
       TriggerFocus a -> a <$ do
         (Tuple _ st) <- getState
-        traverse_ (H.liftEff <<< focus) (spy st.inputElement)
+        traverse_ (H.liftEff <<< focus) st.inputElement
 
       Key ev a -> do
         _ <- eval $ SetVisibility On a
@@ -236,7 +235,6 @@ component =
 
       ToggleVisibility a -> a <$ do
         (Tuple _ st) <- getState
-        _ <- pure $ spy "Visibility toggled"
         case st.visibility of
           Off -> eval $ SetVisibility On a
           On  -> eval $ SetVisibility Off a

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -58,7 +58,6 @@ data Query o item eff a
   | CaptureFocus ET.Event a
   | TriggerFocus a
   | Key KE.KeyboardEvent a
-  | ItemClick Int ME.MouseEvent a
   | PreventClick ME.MouseEvent a
   | SetVisibility Visibility a
   | ToggleVisibility a
@@ -228,10 +227,6 @@ component =
 
       PreventClick ev a -> a <$ do
         H.liftEff <<< preventDefault <<< ME.mouseEventToEvent $ ev
-
-      ItemClick index ev a -> do
-        _ <- eval $ PreventClick ev a
-        eval $ Select index a
 
       SetVisibility v a -> a <$ do
         (Tuple _ st) <- getState

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -45,11 +45,15 @@ setToggleProps = flip (<>)
   [ HE.onFocus $ HE.input $ \ev a ->
       (H.action $ CaptureFocus $ FE.focusEventToEvent ev)
       `andThen`
-      ToggleVisibility a
+      SetVisibility On a
   , HE.onMouseDown $ HE.input $ \ev a ->
       (H.action $ CaptureFocus $ ME.mouseEventToEvent ev)
       `andThen`
-      TriggerFocus a
+      (H.action $ PreventClick ev)
+      `andThen`
+      (H.action TriggerFocus)
+      `andThen`
+      ToggleVisibility a
   , HE.onKeyDown $ HE.input Key
   , HE.onBlur $ HE.input_ $ SetVisibility Off
   , HP.tabIndex 0

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -43,11 +43,11 @@ setToggleProps
   -> Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
 setToggleProps = flip (<>)
   [ HE.onFocus $ HE.input $ \ev a ->
-      (H.action $ CaptureFocus $ FE.focusEventToEvent ev)
+      (H.action $ CaptureRef $ FE.focusEventToEvent ev)
       `andThen`
       SetVisibility On a
   , HE.onMouseDown $ HE.input $ \ev a ->
-      (H.action $ CaptureFocus $ ME.mouseEventToEvent ev)
+      (H.action $ CaptureRef $ ME.mouseEventToEvent ev)
       `andThen`
       (H.action $ PreventClick ev)
       `andThen`
@@ -65,7 +65,7 @@ setInputProps
   -> Array (HP.IProp (InputProps p) (Query o item eff Unit))
 setInputProps = flip (<>)
   [ HE.onFocus $ HE.input $ \ev a ->
-      (H.action $ CaptureFocus $ FE.focusEventToEvent ev)
+      (H.action $ CaptureRef $ FE.focusEventToEvent ev)
       `andThen`
       SetVisibility On a
   , HE.onKeyDown $ HE.input Key

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -5,11 +5,10 @@ import Prelude
 import DOM.Event.FocusEvent as FE
 import DOM.Event.MouseEvent as ME
 import DOM.Event.Types as ET
-import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-import Select (Query(..), Target(..), Visibility(..))
+import Select (Query(..), Target(..), Visibility(..), andThen)
 
 type ToggleProps p =
   ( onFocus :: ET.FocusEvent
@@ -43,10 +42,16 @@ setToggleProps
    . Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
   -> Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
 setToggleProps = flip (<>)
-  [ HE.onFocus     $ HE.input $ CaptureFocusThen (Just $ H.action ToggleVisibility) <<< FE.focusEventToEvent
-  , HE.onKeyDown   $ HE.input Key
-  , HE.onMouseDown $ HE.input $ CaptureFocusThen (Just $ H.action TriggerFocus) <<< ME.mouseEventToEvent
-  , HE.onBlur      $ HE.input_ $ SetVisibility Off
+  [ HE.onFocus $ HE.input $ \ev a ->
+      (H.action $ CaptureFocus $ FE.focusEventToEvent ev)
+      `andThen`
+      ToggleVisibility a
+  , HE.onMouseDown $ HE.input $ \ev a ->
+      (H.action $ CaptureFocus $ ME.mouseEventToEvent ev)
+      `andThen`
+      TriggerFocus a
+  , HE.onKeyDown $ HE.input Key
+  , HE.onBlur $ HE.input_ $ SetVisibility Off
   , HP.tabIndex 0
   ]
 
@@ -55,11 +60,14 @@ setInputProps
    . Array (HP.IProp (InputProps p) (Query o item eff Unit))
   -> Array (HP.IProp (InputProps p) (Query o item eff Unit))
 setInputProps = flip (<>)
-  [ HE.onFocus      $ HE.input $ CaptureFocusThen (Just $ H.action $ SetVisibility On) <<< FE.focusEventToEvent
-  , HE.onKeyDown    $ HE.input Key
+  [ HE.onFocus $ HE.input $ \ev a ->
+      (H.action $ CaptureFocus $ FE.focusEventToEvent ev)
+      `andThen`
+      SetVisibility On a
+  , HE.onKeyDown $ HE.input Key
   , HE.onValueInput $ HE.input Search
-  , HE.onMouseDown  $ HE.input_ $ SetVisibility On
-  , HE.onBlur       $ HE.input_ $ SetVisibility Off
+  , HE.onMouseDown $ HE.input_ $ SetVisibility On
+  , HE.onBlur $ HE.input_ $ SetVisibility Off
   , HP.tabIndex 0
   ]
 

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -2,7 +2,11 @@ module Select.Utils.Setters where
 
 import Prelude
 
+import DOM.Event.FocusEvent as FE
+import DOM.Event.MouseEvent as ME
 import DOM.Event.Types as ET
+import Data.Maybe (Maybe(..))
+import Halogen as H
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Select (Query(..), Target(..), Visibility(..))
@@ -11,6 +15,7 @@ type ToggleProps p =
   ( onFocus :: ET.FocusEvent
   , onKeyDown :: ET.KeyboardEvent
   , onMouseDown :: ET.MouseEvent
+  , onClick :: ET.MouseEvent
   , onBlur :: ET.FocusEvent
   , tabIndex :: Int
   | p
@@ -38,9 +43,10 @@ setToggleProps
    . Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
   -> Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
 setToggleProps = flip (<>)
-  [ HE.onFocus     $ HE.input CaptureFocus
+  [ HE.onFocus     $ HE.input $ CaptureFocusThen Nothing <<< FE.focusEventToEvent
   , HE.onKeyDown   $ HE.input Key
   , HE.onMouseDown $ HE.input_ ToggleVisibility
+  , HE.onClick     $ HE.input $ CaptureFocusThen (Just $ H.action TriggerFocus) <<< ME.mouseEventToEvent
   , HE.onBlur      $ HE.input_ $ SetVisibility Off
   , HP.tabIndex 0
   ]
@@ -50,7 +56,7 @@ setInputProps
    . Array (HP.IProp (InputProps p) (Query o item eff Unit))
   -> Array (HP.IProp (InputProps p) (Query o item eff Unit))
 setInputProps = flip (<>)
-  [ HE.onFocus      $ HE.input CaptureFocus
+  [ HE.onFocus      $ HE.input $ CaptureFocusThen (Just $ H.action $ SetVisibility On) <<< FE.focusEventToEvent
   , HE.onKeyDown    $ HE.input Key
   , HE.onValueInput $ HE.input Search
   , HE.onMouseDown  $ HE.input_ $ SetVisibility On

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -84,6 +84,9 @@ setItemProps
   -> Array (HP.IProp (ItemProps p) (Query o item eff Unit))
   -> Array (HP.IProp (ItemProps p) (Query o item eff Unit))
 setItemProps index = flip (<>)
-  [ HE.onMouseDown $ HE.input  $ ItemClick index
+  [ HE.onMouseDown $ HE.input  $ \ev a ->
+      (H.action $ PreventClick ev)
+      `andThen`
+      Select index a
   , HE.onMouseOver $ HE.input_ $ Highlight (Index index)
   ]

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -10,6 +10,7 @@ import Select (Query(..), Target(..), Visibility(..))
 type ToggleProps p =
   ( onFocus :: ET.FocusEvent
   , onKeyDown :: ET.KeyboardEvent
+  , onMouseDown :: ET.MouseEvent
   , onBlur :: ET.FocusEvent
   , tabIndex :: Int
   | p
@@ -37,9 +38,10 @@ setToggleProps
    . Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
   -> Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
 setToggleProps = flip (<>)
-  [ HE.onFocus    $ HE.input CaptureFocus
-  , HE.onKeyDown  $ HE.input Key
-  , HE.onBlur $ HE.input_ $ SetVisibility Off
+  [ HE.onFocus     $ HE.input CaptureFocus
+  , HE.onKeyDown   $ HE.input Key
+  , HE.onMouseDown $ HE.input_ ToggleVisibility
+  , HE.onBlur      $ HE.input_ $ SetVisibility Off
   , HP.tabIndex 0
   ]
 

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -43,10 +43,9 @@ setToggleProps
    . Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
   -> Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
 setToggleProps = flip (<>)
-  [ HE.onFocus     $ HE.input $ CaptureFocusThen Nothing <<< FE.focusEventToEvent
+  [ HE.onFocus     $ HE.input $ CaptureFocusThen (Just $ H.action ToggleVisibility) <<< FE.focusEventToEvent
   , HE.onKeyDown   $ HE.input Key
-  , HE.onMouseDown $ HE.input_ ToggleVisibility
-  , HE.onClick     $ HE.input $ CaptureFocusThen (Just $ H.action TriggerFocus) <<< ME.mouseEventToEvent
+  , HE.onMouseDown $ HE.input $ CaptureFocusThen (Just $ H.action TriggerFocus) <<< ME.mouseEventToEvent
   , HE.onBlur      $ HE.input_ $ SetVisibility Off
   , HP.tabIndex 0
   ]


### PR DESCRIPTION
## What does this pull request do?

- Captures and maintains focus for toggle-driven select interfaces. This is an issue we weren't previously aware of.
- Introduces a new query, `AndThen`, which allows us to specify more than one action emerging from a single event (for example, toggle visibility AND set focus). Also introduces a helper function, `andThen`, which makes this easy to use in HTML
- Adds a toggle-driven example component for testing purposes
- Fixes: https://github.com/citizennet/purescript-halogen-select/issues/20

## Where should the reviewer start?

All core changes were made in `Select.purs` and `Setters.purs`. You can also review the new example added in `App`.

## How should this be manually tested?

Build the project, and then open the documentation site and click the button example. The button should support these behaviors:

- Clicking should open the menu and maintain focus on the button
- You should be able to use arrow navigation, Enter, and Escape to interact with the menu
- Clicking the toggle when the menu is already open should close the menu
- Clicking away from the toggle should blur and close the menu
- Tabbing on to the menu should open the menu
- Key events used on the toggle when it is closed but focused should open the menu 