### PR TITLE
Update `Select` for PureScript `0.12` and Halogen `4.0.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,28 +13,28 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1.4.0-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
-            - v1.4.0-bower-cache-{{ .Branch }}
-            - v1.4.0-bower-cache
+            - v1.5.0-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
+            - v1.5.0-bower-cache-{{ .Branch }}
+            - v1.5.0-bower-cache
 
       - restore_cache:
           keys:
-            - v1.4.0-yarn-cache-{{ .Branch }}-{{ checksum "package.json" }}
-            - v1.4.0-yarn-cache-{{ .Branch }}
-            - v1.4.0-yarn-cache
+            - v1.5.0-yarn-cache-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1.5.0-yarn-cache-{{ .Branch }}
+            - v1.5.0-yarn-cache
 
       - run:
           name: Install dependencies from Yarn and Bower
           command: yarn
 
       - save_cache:
-          key: v1.4.0-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
+          key: v1.5.0-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
           paths:
             - ~/select/bower_components
             - ~/select/output
 
       - save_cache:
-          key: v1.4.0-yarn-cache-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v1.5.0-yarn-cache-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - ~/select/node_modules
 

--- a/bower.json
+++ b/bower.json
@@ -31,27 +31,27 @@
     "generated-docs"
   ],
   "dependencies": {
-    "purescript-halogen": "^3.1.1",
-    "purescript-control": "^3.3.1",
-    "purescript-transformers": "^3.5.0",
-    "purescript-dom": "^4.15.0",
-    "purescript-aff": "^4.0.0"
+    "purescript-halogen": "^4.0.0",
+    "purescript-control": "^4.0.0",
+    "purescript-transformers": "^4.1.0",
+    "purescript-dom": "^4.16.0",
+    "purescript-aff": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-dom-classy": "^2.1.0",
-    "purescript-remotedata": "^2.2.0",
-    "purescript-console": "^3.0.0",
-    "purescript-css": "^3.4.0",
+    "purescript-dom-classy": "^2.2.0",
+    "purescript-remotedata": "^3.0.0",
+    "purescript-console": "^4.1.0",
+    "purescript-css": "^4.0.0",
     "purescript-halogen-css": "^7.0.0",
-    "purescript-datetime": "^3.4.1",
-    "purescript-formatters": "^3.0.1",
-    "purescript-debug": "^3.0.0",
-    "purescript-now": "^3.0.0",
-    "purescript-js-timers": "^3.0.0",
-    "purescript-routing": "^7.0.0",
-    "purescript-coroutines": "^4.0.0",
-    "purescript-aff-coroutines": "^6.0.0",
-    "purescript-affjax": "^5.0.0",
-    "purescript-strings": "^3.5.0"
+    "purescript-datetime": "^4.0.0",
+    "purescript-formatters": "^3.0.2",
+    "purescript-debug": "^4.0.0",
+    "purescript-now": "^4.0.0",
+    "purescript-js-timers": "^4.0.0",
+    "purescript-routing": "^8.0.0",
+    "purescript-coroutines": "^5.0.0",
+    "purescript-aff-coroutines": "^7.0.0",
+    "purescript-affjax": "^6.0.0",
+    "purescript-strings": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -39,5 +39,8 @@
     "purescript-web-uievents": "^1.0.0",
     "purescript-avar": "^3.0.0",
     "purescript-web-events": "^1.0.0"
+  },
+  "devDependencies": {
+    "purescript-debug": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -32,26 +32,12 @@
   ],
   "dependencies": {
     "purescript-halogen": "^4.0.0",
-    "purescript-control": "^4.0.0",
+    "purescript-web-html": "^1.0.0",
+    "purescript-aff": "^5.0.0",
     "purescript-transformers": "^4.1.0",
-    "purescript-dom": "^4.16.0",
-    "purescript-aff": "^5.0.0"
-  },
-  "devDependencies": {
-    "purescript-dom-classy": "^2.2.0",
-    "purescript-remotedata": "^3.0.0",
-    "purescript-console": "^4.1.0",
-    "purescript-css": "^4.0.0",
-    "purescript-halogen-css": "^7.0.0",
-    "purescript-datetime": "^4.0.0",
-    "purescript-formatters": "^3.0.2",
-    "purescript-debug": "^4.0.0",
-    "purescript-now": "^4.0.0",
-    "purescript-js-timers": "^4.0.0",
-    "purescript-routing": "^8.0.0",
-    "purescript-coroutines": "^5.0.0",
-    "purescript-aff-coroutines": "^7.0.0",
-    "purescript-affjax": "^6.0.0",
-    "purescript-strings": "^4.0.0"
+    "purescript-control": "^4.0.0",
+    "purescript-web-uievents": "^1.0.0",
+    "purescript-avar": "^3.0.0",
+    "purescript-web-events": "^1.0.0"
   }
 }

--- a/examples/Internal/Component.purs
+++ b/examples/Internal/Component.purs
@@ -4,12 +4,7 @@ module Docs.Internal.Component where
 
 import Prelude
 
-import Control.Monad.Aff.Class (class MonadAff)
-import Control.Monad.Eff.AVar (AVAR)
-import Control.Monad.Eff.Console (CONSOLE)
-import Control.Monad.Eff.Now (NOW)
-import Control.Monad.Eff.Timer (TIMER)
-import DOM (DOM)
+import Effect.Aff.Class (class MonadAff)
 import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
@@ -30,12 +25,10 @@ type Component m = H.Component HH.HTML Query Unit Void m
 type DSL q m = H.ParentDSL State Query q Unit Void m
 type HTML q m = H.ParentHTML Query q Unit m
 
-type Effects eff = ( console :: CONSOLE, dom :: DOM, now :: NOW, avar :: AVAR, timer :: TIMER | eff )
-
 ----------
 -- Built components
 
-typeahead :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
+typeahead :: ∀ m. MonadAff m => Component m
 typeahead =
   H.parentComponent
     { initialState: const unit
@@ -60,7 +53,7 @@ typeahead =
       , "Rico Suave"
       ]
 
-dropdown :: ∀ eff m. MonadAff ( Effects eff ) m => Component m
+dropdown :: ∀ m. MonadAff m => Component m
 dropdown =
   H.parentComponent
     { initialState: const unit

--- a/examples/Internal/Proxy.purs
+++ b/examples/Internal/Proxy.purs
@@ -32,7 +32,7 @@ proxyEval
   -> H.Component HH.HTML (ProxyS g i) i Void m
 proxyEval evalQuery component =
   H.parentComponent
-    { initialState: id
+    { initialState: identity
     , render
     , eval
     , receiver: const Nothing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
   "scripts": {
+    "build": "pulp build",
+    "watch": "pulp -w build",
     "build-docs": "pulp build -I examples --to docs/js/app.js",
     "watch-docs": "pulp -w --then 'mkdocs serve' build -I examples --to docs/js/app.js",
     "clean": "rm -rf output bower_components node_modules site docs/js docs/css",
@@ -8,11 +10,10 @@
     "fetch-css": "curl https://cdn.rawgit.com/citizennet/purescript-ocelot/dev/dist/cn-tailwind.scoped.css --output cn-tailwind.scoped.css",
     "move-css": "mkdir -p docs/css/ && mv cn-tailwind.scoped.css docs/css/"
   },
-  "devDependencies": {
-    "pulp": "^12.2.0",
-    "purescript": "^0.12.0"
-  },
+  "devDependencies": {},
   "dependencies": {
-    "npm-check-updates": "^2.14.2"
+    "global": "^4.3.2",
+    "npm-check-updates": "^2.14.2",
+    "purescript": "^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "move-css": "mkdir -p docs/css/ && mv cn-tailwind.scoped.css docs/css/"
   },
   "devDependencies": {
-    "pulp": "^12.0.1",
-    "purescript": "^0.11.7"
+    "pulp": "^12.2.0",
+    "purescript": "^0.12.0"
   },
   "dependencies": {
-    "npm-check-updates": "^2.14.0"
+    "npm-check-updates": "^2.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "global": "^4.3.2",
     "npm-check-updates": "^2.14.2",
+    "pulp": "^12.2.0",
     "purescript": "^0.12.0"
   }
 }

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -19,7 +19,6 @@ import Web.UIEvent.KeyboardEvent as KE
 import Web.UIEvent.MouseEvent as ME
 import Web.HTML.HTMLElement (HTMLElement, blur, focus, fromEventTarget)
 import Data.Array (length, (!!))
-import Data.Either (hush)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Milliseconds(..))
 import Data.Traversable (for_, traverse_)

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -13,13 +13,11 @@ import Effect.Aff (Fiber, delay, error, forkAff, killFiber)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Aff.AVar (AVar)
 import Effect.Aff.AVar as AVar
-import Foreign (unsafeToForeign, unsafeFromForeign)
-import Control.Monad.Except (runExcept)
 import Control.Monad.Free (Free, foldFree, liftF)
 import Web.Event.Event (preventDefault, currentTarget, Event)
 import Web.UIEvent.KeyboardEvent as KE
 import Web.UIEvent.MouseEvent as ME
-import Web.HTML.HTMLElement (HTMLElement, blur, focus)
+import Web.HTML.HTMLElement (HTMLElement, blur, focus, fromEventTarget)
 import Data.Array (length, (!!))
 import Data.Either (hush)
 import Data.Maybe (Maybe(..), fromMaybe)
@@ -343,13 +341,7 @@ component =
 
       CaptureRef event a -> a <$ do
         (Tuple _ st) <- getState
-        let elementFromEvent
-              = hush
-              <<< runExcept
-              <<< unsafeFromForeign
-              <<< unsafeToForeign
-              <<< currentTarget
-        H.modify_ $ seeks _ { inputElement = elementFromEvent event }
+        H.modify_ $ seeks _ { inputElement = fromEventTarget =<< currentTarget event }
         pure a
 
       Focus focusOrBlur a -> a <$ do

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -9,26 +9,24 @@ import Prelude
 
 import Control.Comonad (extract)
 import Control.Comonad.Store (Store, seeks, store)
-import Control.Monad.Aff (Fiber, delay, error, forkAff, killFiber)
-import Control.Monad.Aff.AVar (AVar, makeEmptyVar, putVar, takeVar, AVAR)
-import Control.Monad.Aff.Class (class MonadAff)
+import Effect.Aff (Fiber, delay, error, forkAff, killFiber)
+import Effect.Aff.Class (class MonadAff)
+import Effect.Aff.AVar (AVar)
+import Effect.Aff.AVar as AVar
+import Foreign (unsafeToForeign, unsafeFromForeign)
 import Control.Monad.Except (runExcept)
 import Control.Monad.Free (Free, foldFree, liftF)
-import DOM (DOM)
-import DOM.Event.Event (preventDefault, currentTarget)
-import DOM.Event.KeyboardEvent as KE
-import DOM.Event.MouseEvent as ME
-import DOM.Event.Types as ET
-import DOM.HTML.HTMLElement (blur, focus)
-import DOM.HTML.Types (HTMLElement, readHTMLElement)
+import Web.Event.Event (preventDefault, currentTarget, Event)
+import Web.UIEvent.KeyboardEvent as KE
+import Web.UIEvent.MouseEvent as ME
+import Web.HTML.HTMLElement (HTMLElement, blur, focus)
 import Data.Array (length, (!!))
 import Data.Either (hush)
-import Data.Foreign (toForeign)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Milliseconds(..))
 import Data.Traversable (for_, traverse_)
 import Data.Tuple (Tuple(..))
-import Halogen (Component, ComponentDSL, ComponentHTML, component, liftAff, liftEff, modify) as H
+import Halogen (Component, ComponentDSL, ComponentHTML, component, liftAff, liftEffect, modify) as H
 import Halogen.HTML as HH
 import Halogen.Query.HalogenM (fork, raise) as H
 import Select.Internal.State (updateStore, getState)
@@ -37,26 +35,22 @@ import Select.Internal.State (updateStore, getState)
 -- Component Types
 
 -- | A useful shorthand for the Halogen component type
-type Component o item eff m
-  = H.Component HH.HTML (Query o item eff) (Input o item eff) (Message o item) m
+type Component o item m
+  = H.Component HH.HTML (Query o item) (Input o item) (Message o item) m
 
 -- | A useful shorthand for the Halogen component HTML type
-type ComponentHTML o item eff
-  = H.ComponentHTML (Query o item eff)
+type ComponentHTML o item
+  = H.ComponentHTML (Query o item)
 
 -- | A useful shorthand for the Halogen component DSL type
-type ComponentDSL o item eff m
-  = H.ComponentDSL (StateStore o item eff) (Query o item eff) (Message o item) m
+type ComponentDSL o item m
+  = H.ComponentDSL (StateStore o item) (Query o item) (Message o item) m
 
 -- | The component's state type, wrapped in `Store`. The state and result of the
 -- | render function are stored so that `extract` from `Control.Comonad` can be
 -- | used to pull out the render function.
-type StateStore o item eff
-  = Store (State item eff) (ComponentHTML o item eff)
-
--- | The effects necessary for this component to run. Your component will need to
--- | also support these effects.
-type Effects eff = ( avar :: AVAR, dom :: DOM | eff )
+type StateStore o item
+  = Store (State item) (ComponentHTML o item)
 
 ----------
 -- Core Constructors
@@ -68,16 +62,15 @@ type Effects eff = ( avar :: AVAR, dom :: DOM | eff )
 -- |        This allows you to embed your own queries into the `Select` component.
 -- | - `item`: Your custom item type. It can be a simple type like `String`, or something
 -- |           complex like `CalendarItem StartDate EndDate (Maybe Disabled)`.
--- | - `eff`: The component's effects.
 -- |
 -- | See the below functions for documentation for the individual constructors.
 -- | The README details how to use them in Halogen code, since the patterns
 -- | are a little different.
-data QueryF o item eff a
+data QueryF o item a
   = Search String a
   | Highlight Target a
   | Select Int a
-  | CaptureRef ET.Event a
+  | CaptureRef Event a
   | Focus Boolean a
   | Key KE.KeyboardEvent a
   | PreventClick ME.MouseEvent a
@@ -85,76 +78,76 @@ data QueryF o item eff a
   | GetVisibility (Visibility -> a)
   | ReplaceItems (Array item) a
   | Raise (o Unit) a
-  | Receive (Input o item eff) a
+  | Receive (Input o item) a
 
-type Query o item eff = Free (QueryF o item eff)
+type Query o item = Free (QueryF o item)
 
 -- | Trigger the relevant action with the event each time it occurs
 always :: ∀ a b. a -> b -> Maybe a
 always = const <<< Just
 
 -- | Perform a new search with the included string.
-search :: ∀ o item eff. String -> Query o item eff Unit
+search :: ∀ o item. String -> Query o item Unit
 search s = liftF (Search s unit)
 
 -- | Change the highlighted index to the next item, previous item, or a
 -- | specific index.
-highlight :: ∀ o item eff. Target -> Query o item eff Unit
+highlight :: ∀ o item. Target -> Query o item Unit
 highlight t = liftF (Highlight t unit)
 
 -- | Triggers the "Selected" message for the item at the specified index.
-select :: ∀ o item eff. Int -> Query o item eff Unit
+select :: ∀ o item. Int -> Query o item Unit
 select i = liftF (Select i unit)
 
 -- | From an event, captures a reference to the element that triggered the
 -- | event. Used to manage focus / blur for elements without requiring a
 -- | particular identifier.
-captureRef :: ∀ o item eff. ET.Event -> Query o item eff Unit
+captureRef :: ∀ o item. Event -> Query o item Unit
 captureRef r = liftF (CaptureRef r unit)
 
 -- | Trigger the DOM focus event for the element we have a reference to.
-triggerFocus :: ∀ o item eff. Query o item eff Unit
+triggerFocus :: ∀ o item . Query o item Unit
 triggerFocus = liftF (Focus true unit)
 
 -- | Trigger the DOM blur event for the element we have a reference to
-triggerBlur :: ∀ o item eff. Query o item eff Unit
+triggerBlur :: ∀ o item . Query o item Unit
 triggerBlur = liftF (Focus false unit)
 
 -- | Register a key event. `TextInput`-driven components use these only for
 -- | navigation, whereas `Toggle`-driven components also use the key stream for
 -- | highlighting.
-key :: ∀ o item eff. KE.KeyboardEvent -> Query o item eff Unit
+key :: ∀ o item . KE.KeyboardEvent -> Query o item Unit
 key e = liftF (Key e unit)
 
 -- | A helper query to prevent click events from bubbling up.
-preventClick :: ∀ o item eff. ME.MouseEvent -> Query o item eff Unit
+preventClick :: ∀ o item . ME.MouseEvent -> Query o item Unit
 preventClick i = liftF (PreventClick i unit)
 
 -- | Set the container visibility (`On` or `Off`)
-setVisibility :: ∀ o item eff. Visibility -> Query o item eff Unit
+setVisibility :: ∀ o item . Visibility -> Query o item Unit
 setVisibility v = liftF (SetVisibility v unit)
 
 -- | Get the container visibility (`On` or `Off`). Most useful when sequenced
 -- | with other actions.
-getVisibility :: ∀ o item eff. Query o item eff Visibility
-getVisibility = liftF (GetVisibility id)
+getVisibility :: ∀ o item . Query o item Visibility
+getVisibility = liftF (GetVisibility identity)
 
 -- | Toggles the container visibility.
-toggleVisibility :: ∀ o item eff. Query o item eff Unit
+toggleVisibility :: ∀ o item . Query o item Unit
 toggleVisibility = getVisibility >>= not >>> setVisibility
 
 -- | Replaces all items in state with the new array of items.
-replaceItems :: ∀ o item eff. Array item -> Query o item eff Unit
+replaceItems :: ∀ o item . Array item -> Query o item Unit
 replaceItems items = liftF (ReplaceItems items unit)
 
 -- | A helper query that the component that mounts `Select` can use to embed its
 -- | own queries. Triggers an `Emit` message containing the query when triggered.
 -- | This can be used to easily extend `Select` with more behaviors.
-raise :: ∀ o item eff. o Unit -> Query o item eff Unit
+raise :: ∀ o item . o Unit -> Query o item Unit
 raise o = liftF (Raise o unit)
 
 -- | Sets the component with new input.
-receive :: ∀ o item eff. Input o item eff -> Query o item eff Unit
+receive :: ∀ o item . Input o item -> Query o item Unit
 receive i = liftF (Receive i unit)
 
 -- | Represents a way to navigate on `Highlight` events: to the previous
@@ -211,11 +204,11 @@ data InputType
 -- | - `highlightedIndex`: What item in the array of items should be considered
 -- |                       highlighted. Useful for rendering.
 -- | - `lastIndex`: The length of the array of items.
-type State item eff =
+type State item =
   { inputType        :: InputType
   , search           :: String
   , debounceTime     :: Milliseconds
-  , debouncer        :: Maybe (Debouncer eff)
+  , debouncer        :: Maybe Debouncer
   , inputElement     :: Maybe HTMLElement
   , items            :: Array item
   , visibility       :: Visibility
@@ -224,20 +217,20 @@ type State item eff =
   }
 
 -- | Represents a running computation that, when it completes, will trigger debounced
--- | effects.
-type Debouncer eff =
+-- | .cts.
+type Debouncer =
   { var   :: AVar Unit
-  , fiber :: Fiber eff Unit }
+  , fiber :: Fiber Unit }
 
 -- | The component's input type, which includes the component's render function. This
 -- | render function can also be used to share data with the parent component, as every
 -- | time the parent re-renders, the render function will refresh in `Select`.
-type Input o item eff =
+type Input o item =
   { inputType     :: InputType
   , items         :: Array item
   , initialSearch :: Maybe String
   , debounceTime  :: Maybe Milliseconds
-  , render        :: State item eff -> ComponentHTML o item eff
+  , render        :: State item -> ComponentHTML o item
   }
 
 -- | The parent is only notified for a few important events, but `Emit` makes it
@@ -254,9 +247,9 @@ data Message o item
   | VisibilityChanged Visibility
   | Emit (o Unit)
 
-component :: ∀ o item eff m
-  . MonadAff (Effects eff) m
- => Component o item (Effects eff) m
+component :: ∀ o item m
+  . MonadAff m
+ => Component o item m
 component =
   H.component
     { initialState
@@ -278,7 +271,7 @@ component =
       }
 
     -- Construct the fold over the free monad based on the stepwise eval
-    eval' :: Query o item (Effects eff) ~> ComponentDSL o item (Effects eff) m
+    eval' :: Query o item ~> ComponentDSL o item m
     eval' a = foldFree eval a
 
     -- Helper for setting visibility inside `eval`. Eta-expanded bc strict
@@ -286,7 +279,7 @@ component =
     setVis v = eval' (setVisibility v)
 
     -- Just the normal Halogen eval
-    eval :: (QueryF o item (Effects eff)) ~> ComponentDSL o item (Effects eff) m
+    eval :: QueryF o item ~> ComponentDSL o item m
     eval = case _ of
       Search str a -> a <$ do
         (Tuple _ st) <- getState
@@ -295,15 +288,15 @@ component =
 
         case st.inputType, st.debouncer of
           TextInput, Nothing -> unit <$ do
-            var   <- H.liftAff makeEmptyVar
+            var   <- H.liftAff AVar.empty
             fiber <- H.liftAff $ forkAff do
               delay st.debounceTime
-              putVar unit var
+              AVar.put unit var
 
             -- This compututation will fork and run in the background. When the
-            -- var is finally filled, the effect will run (raise a new search)
+            -- var is finally filled, the .ct will run (raise a new search)
             _ <- H.fork do
-              _ <- H.liftAff $ takeVar var
+              _ <- H.liftAff $ AVar.take var
               H.modify $ seeks _ { debouncer = Nothing, highlightedIndex = Just 0 }
               (Tuple _ newState) <- getState
               H.raise $ Searched newState.search
@@ -315,7 +308,7 @@ component =
             _ <- H.liftAff $ killFiber (error "Time's up!") debouncer.fiber
             fiber <- H.liftAff $ forkAff do
               delay st.debounceTime
-              putVar unit var
+              AVar.put unit var
 
             H.modify $ seeks _ { debouncer = Just { var, fiber } }
 
@@ -324,11 +317,9 @@ component =
           _, _ -> pure unit
 
       Highlight target a -> a <$ do
-        Tuple _ st <- getState
-        when (st.visibility /= Off) do
-          let
-            hi =
-              case target of
+        (Tuple _ st) <- getState
+        when (st.visibility /= Off) $ do
+          let highlightedIndex = case target of
                 Prev  -> case st.highlightedIndex of
                   Just i | i /= 0 ->
                     Just (i - 1)
@@ -341,7 +332,7 @@ component =
                     Just 0
                 Index i ->
                   Just i
-          H.modify $ seeks _ { highlightedIndex = hi }
+          H.modify $ seeks _ { highlightedIndex = highlightedIndex }
 
       Select index a -> a <$ do
         (Tuple _ st) <- getState
@@ -354,26 +345,26 @@ component =
         let elementFromEvent
               = hush
               <<< runExcept
-              <<< readHTMLElement
-              <<< toForeign
+              <<< unsafeFromForeign
+              <<< unsafeToForeign
               <<< currentTarget
         H.modify $ seeks _ { inputElement = elementFromEvent event }
         pure a
 
       Focus focusOrBlur a -> a <$ do
         (Tuple _ st) <- getState
-        traverse_ (H.liftEff <<< if focusOrBlur then focus else blur) st.inputElement
+        traverse_ (H.liftEffect <<< if focusOrBlur then focus else blur) st.inputElement
 
       Key ev a -> a <$ do
         setVis On
-        let preventIt = H.liftEff $ preventDefault $ KE.keyboardEventToEvent ev
+        let preventIt = H.liftEffect $ preventDefault $ KE.toEvent ev
         case KE.code ev of
           "ArrowUp"   -> preventIt *> eval' (highlight Prev)
           "ArrowDown" -> preventIt *> eval' (highlight Next)
           "Escape"    -> do
             (Tuple _ st) <- getState
             preventIt
-            for_ st.inputElement (H.liftEff <<< blur)
+            for_ st.inputElement (H.liftEffect <<< blur)
           "Enter"     -> do
             (Tuple _ st) <- getState
             preventIt
@@ -381,7 +372,7 @@ component =
           otherKey    -> pure unit
 
       PreventClick ev a -> a <$ do
-        H.liftEff <<< preventDefault <<< ME.mouseEventToEvent $ ev
+        H.liftEffect <<< preventDefault <<< ME.toEvent $ ev
 
       SetVisibility v a -> a <$ do
         (Tuple _ st) <- getState
@@ -403,4 +394,4 @@ component =
         H.raise (Emit parentQuery)
 
       Receive input a -> a <$ do
-        H.modify (updateStore input.render id)
+        H.modify (updateStore input.render identity)

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -6,9 +6,9 @@ module Select.Utils.Setters where
 
 import Prelude
 
-import DOM.Event.FocusEvent as FE
-import DOM.Event.MouseEvent as ME
-import DOM.Event.Types as ET
+import Web.UIEvent.FocusEvent as FE
+import Web.UIEvent.MouseEvent as ME
+import Web.UIEvent.EventTypes as ET
 import Data.Maybe (Maybe(..))
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP

--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -8,7 +8,8 @@ import Prelude
 
 import Web.UIEvent.FocusEvent as FE
 import Web.UIEvent.MouseEvent as ME
-import Web.UIEvent.EventTypes as ET
+import Web.UIEvent.KeyboardEvent as KE
+import Web.Event.Event (Event)
 import Data.Maybe (Maybe(..))
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
@@ -18,11 +19,11 @@ import Select as Select
 -- | The properties that must be supported by the HTML element that serves
 -- | as a menu toggle. This should be used with toggle-driven `Select` components.
 type ToggleProps p =
-  ( onFocus :: ET.FocusEvent
-  , onKeyDown :: ET.KeyboardEvent
-  , onMouseDown :: ET.MouseEvent
-  , onClick :: ET.MouseEvent
-  , onBlur :: ET.FocusEvent
+  ( onFocus :: FE.FocusEvent
+  , onKeyDown :: KE.KeyboardEvent
+  , onMouseDown :: ME.MouseEvent
+  , onClick :: ME.MouseEvent
+  , onBlur :: FE.FocusEvent
   , tabIndex :: Int
   | p
   )
@@ -36,15 +37,15 @@ type ToggleProps p =
 -- | renderToggle = div (setToggleProps [ class "btn-class" ]) [ ...html ]
 -- | ```
 setToggleProps
-  :: ∀ o item eff p
-   . Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
-  -> Array (HP.IProp (ToggleProps p) (Query o item eff Unit))
+  :: ∀ o item p
+   . Array (HP.IProp (ToggleProps p) (Query o item Unit))
+  -> Array (HP.IProp (ToggleProps p) (Query o item Unit))
 setToggleProps = flip (<>)
   [ HE.onFocus \ev -> Just do
-      Select.captureRef $ FE.focusEventToEvent ev
+      Select.captureRef $ FE.toEvent ev
       Select.setVisibility On
   , HE.onMouseDown \ev -> Just do
-      Select.captureRef $ ME.mouseEventToEvent ev
+      Select.captureRef $ ME.toEvent ev
       Select.preventClick ev
       Select.getVisibility >>= case _ of
         Select.On -> do
@@ -61,12 +62,12 @@ setToggleProps = flip (<>)
 -- | The properties that must be supported by the HTML element that serves
 -- | as a text input. This should be used with input-driven `Select` components.
 type InputProps p =
-  ( onFocus :: ET.FocusEvent
-  , onKeyDown :: ET.KeyboardEvent
-  , onInput :: ET.Event
+  ( onFocus :: FE.FocusEvent
+  , onKeyDown :: KE.KeyboardEvent
+  , onInput :: Event
   , value :: String
-  , onMouseDown :: ET.MouseEvent
-  , onBlur :: ET.FocusEvent
+  , onMouseDown :: ME.MouseEvent
+  , onBlur :: FE.FocusEvent
   , tabIndex :: Int
   | p
   )
@@ -80,12 +81,12 @@ type InputProps p =
 -- | renderInput = input_ (setInputProps [ class "my-class" ])
 -- | ```
 setInputProps
-  :: ∀ o item eff p
-   . Array (HP.IProp (InputProps p) (Query o item eff Unit))
-  -> Array (HP.IProp (InputProps p) (Query o item eff Unit))
+  :: ∀ o item p
+   . Array (HP.IProp (InputProps p) (Query o item Unit))
+  -> Array (HP.IProp (InputProps p) (Query o item Unit))
 setInputProps = flip (<>)
   [ HE.onFocus \ev -> Just do
-      Select.captureRef $ FE.focusEventToEvent ev
+      Select.captureRef $ FE.toEvent ev
       Select.setVisibility On
   , HE.onKeyDown $ Just <<< Select.key
   , HE.onValueInput $ Just <<< Select.search
@@ -98,8 +99,8 @@ setInputProps = flip (<>)
 -- | selectable "item" in your UI. This should be attached to every item that
 -- | can be selected.
 type ItemProps p =
-  ( onMouseDown :: ET.MouseEvent
-  , onMouseOver :: ET.MouseEvent
+  ( onMouseDown :: ME.MouseEvent
+  , onMouseOver :: ME.MouseEvent
   | p
   )
 
@@ -115,10 +116,10 @@ type ItemProps p =
 -- | render = renderItem `mapWithIndex` itemsArray
 -- | ```
 setItemProps
-  :: ∀ o item eff p
+  :: ∀ o item p
    . Int
-  -> Array (HP.IProp (ItemProps p) (Query o item eff Unit))
-  -> Array (HP.IProp (ItemProps p) (Query o item eff Unit))
+  -> Array (HP.IProp (ItemProps p) (Query o item Unit))
+  -> Array (HP.IProp (ItemProps p) (Query o item Unit))
 setItemProps index = flip (<>)
   [ HE.onMouseDown \ev -> Just do
       Select.preventClick ev
@@ -131,8 +132,8 @@ setItemProps index = flip (<>)
 -- | will not bubble up a blur event to the DOM. This should be used on the parent
 -- | element that contains your items.
 setContainerProps
-  :: ∀ o item eff p
-   . Array (HP.IProp (onMouseDown :: ET.MouseEvent | p) (Query o item eff Unit))
-  -> Array (HP.IProp (onMouseDown :: ET.MouseEvent | p) (Query o item eff Unit))
+  :: ∀ o item p
+   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | p) (Query o item Unit))
+  -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | p) (Query o item Unit))
 setContainerProps = flip (<>)
   [ HE.onMouseDown $ Just <<< Select.preventClick ]


### PR DESCRIPTION
## What does this pull request do?

This PR updates Select for compatibility with Halogen 4.0.0 and PureScript 0.12.

## How should this be manually tested?

Run `yarn watch-docs`, navigate to the Examples page, and verify the console reports no errors and the typeahead and dropdown function as expected.

## Other Notes:

Project documentation will need an update and the library needs a major version bump. We'll probably need to do another major version bump as soon as Halogen moves to `5.0.0`.

Fixes #24 
