### PR TITLE
Added const version of setter props

### DIFF
--- a/src/Utils/Setters.purs
+++ b/src/Utils/Setters.purs
@@ -84,7 +84,12 @@ setInputProps
   :: ∀ o item p
    . Array (HP.IProp (InputProps p) (Query o item Unit))
   -> Array (HP.IProp (InputProps p) (Query o item Unit))
-setInputProps = flip (<>)
+setInputProps = flip (<>) inputProps
+
+inputProps
+  :: ∀ o item p
+   . Array (HP.IProp (InputProps p) (Query o item Unit))
+inputProps =
   [ HE.onFocus \ev -> Just do
       Select.captureRef $ FE.toEvent ev
       Select.setVisibility On
@@ -120,7 +125,13 @@ setItemProps
    . Int
   -> Array (HP.IProp (ItemProps p) (Query o item Unit))
   -> Array (HP.IProp (ItemProps p) (Query o item Unit))
-setItemProps index = flip (<>)
+setItemProps = flip (<>) <<< itemProps
+
+itemProps
+  :: ∀ o item p
+   . Int
+  -> Array (HP.IProp (ItemProps p) (Query o item Unit))
+itemProps index =
   [ HE.onMouseDown \ev -> Just do
       Select.preventClick ev
       Select.select index
@@ -135,5 +146,10 @@ setContainerProps
   :: ∀ o item p
    . Array (HP.IProp (onMouseDown :: ME.MouseEvent | p) (Query o item Unit))
   -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | p) (Query o item Unit))
-setContainerProps = flip (<>)
+setContainerProps = flip (<>) containerProps
+
+containerProps
+  :: ∀ o item p
+   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | p) (Query o item Unit))
+containerProps =
   [ HE.onMouseDown $ Just <<< Select.preventClick ]


### PR DESCRIPTION
## What does this pull request do?

Moved all the props in `Setters` to their own const value and then referenced those from the setter functions. That way if I do want to override them, I can do something like:

```
HH.input ( Setters.inputProps <> [ HE.onValueInput $ const Nothing ] )
```

Instead of:

```
HH.input ( Setters.setInputProps [] <> [ HE.onValueInput $ const Nothing ] )
```

It's a very minor ergonomic improvement, but also avoids doing some pointless `flip` and extra `<>` operations.
