### PR TITLE
Fix a couple of typos in dropdown tutorial

### DIFF
--- a/docs/tutorials/dropdown.md
+++ b/docs/tutorials/dropdown.md
@@ -132,7 +132,7 @@ The first thing we'll do is bring in the `Select` library in the first place.
 
 ```hs
 import Select as Select
-import Select.Utils.Setters as Setters
+import Select.Setters as Setters
 ```
 
 !!! tip
@@ -349,7 +349,7 @@ It's now time to turn your static HTML into a fully-functioning dropdown.
 - An element that contains those items
 - A focusable element that can be used to toggle visibility and capture keystrokes
 
-Accordingly, you'll need to use three helper functions, each exported by the `Select.Utils.Setters` module:
+Accordingly, you'll need to use three helper functions, each exported by the `Select.Setters` module:
 
 - `setItemProps`
 - `setContainerProps`
@@ -584,7 +584,7 @@ If you'd like to use this component as a starting point from which to build your
     import Halogen.HTML.Events as HE
     import Halogen.HTML.Properties as HP
     import Select as Select
-    import Select.Utils.Setters as Setters
+    import Select.Setters as Setters
 
     data Query a
       = HandleSelect (Select.Message Query String) a

--- a/docs/tutorials/typeahead.md
+++ b/docs/tutorials/typeahead.md
@@ -92,7 +92,7 @@ Now let's make sure we have `Select` ready to go in our component. Import the li
 
 ```hs
 import Select as Select
-import Select.Utils.Setters as Setters
+import Select.Setters as Setters
 ```
 
 Next, since `Select` is going to be a child component, we'll need to update several types and functions. We will:
@@ -589,7 +589,7 @@ renderInput = HH.input ( Setters.setInputProps [] )
 That's it! Now we have all the key events wired up for you. You could embed your own queries here, or add CSS, or whatever you want and the behavior will still work just fine.
 
 !!! warning
-    `Select` will append the properties it needs to the input field, including `#!hs onMouseDown`, `#! onValueInput`, and so on. Unfortunately there can only be one of these handlers in the list of properties, so if you already placed an `#!hs onValueInput` handler it will be overwritten by `Select`. If you need to trigger some new functionality from the same handler that `Select` is using, then you can always write a custom `#!hs setInputProps` function for yourself that routes the event to your own query *and* the relevant `Select` query. Take a look at the module documentation for `Select.Utils.Setters` to see how.
+    `Select` will append the properties it needs to the input field, including `#!hs onMouseDown`, `#! onValueInput`, and so on. Unfortunately there can only be one of these handlers in the list of properties, so if you already placed an `#!hs onValueInput` handler it will be overwritten by `Select`. If you need to trigger some new functionality from the same handler that `Select` is using, then you can always write a custom `#!hs setInputProps` function for yourself that routes the event to your own query *and* the relevant `Select` query. Take a look at the module documentation for `Select.Setters` to see how.
 
 Next, let's render the actual items. Remember that we need to use `#!hs setContainerProps` on the containing element (in this case `#!hs HH.ul`) and `#!hs setItemProps` on each item.
 
@@ -681,7 +681,7 @@ If you'd like to use this component as a starting point from which to build your
     import Network.HTTP.Affjax.Respondable as Respondable
     import Network.RemoteData (RemoteData(..), fromEither, withDefault)
     import Select as Select
-    import Select.Utils.Setters as Setters
+    import Select.Setters as Setters
 
     data Query a
       = HandleSelect (Select.Message Query String) a

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -1,6 +1,6 @@
 -- | This module exposes a component that can be used to build accessible selection
 -- | user interfaces. You are responsible for providing all rendering, with the help
--- | of the `Select.Utils.Setters` module, but this component provides the relevant
+-- | of the `Select.Setters` module, but this component provides the relevant
 -- | behaviors for dropdowns, autocompletes, typeaheads, keyboard-navigable calendars,
 -- | and other selection UIs.
 module Select where


### PR DESCRIPTION
## What does this pull request do?

`import Select.Utils.Setters as Setters` -> `import Select.Setters as Setters` :)