### PR TITLE
Fix a typo

### DIFF
--- a/docs/tutorials/dropdown.md
+++ b/docs/tutorials/dropdown.md
@@ -98,7 +98,7 @@ render st =
   ]
 
 dropdown :: State -> H.ParentHTML Query ChildQuery ChildSlot m
-dropdown =
+dropdown st =
   HH.div_
   [ HH.button_
     [ HH.text $ fromMaybe "Click me to view some items" st.selectedItem ]


### PR DESCRIPTION
I noticed a typo while going through the tutorial and decided to fix it.
Without this change you would get the following error:

```
Error found:
in module Component
at src/Component.purs line 66, column 59 - line 66, column 61

  Unknown value st

```
