### PR TITLE
Input/Toggle Reference

### DIFF
--- a/docs/tutorials/dropdown.md
+++ b/docs/tutorials/dropdown.md
@@ -152,7 +152,7 @@ Error found:
 in type synonym ChildQuery
 ```
 
-The compiler has noticed that `#!hs ChildQuery`, a type synonym, is partially applied. That's because `#!hs Select.Query`, itself a type synonym, takes several arguments as described in the [module documentation on Pursuit](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Query). Let's walk through each one:
+The compiler has noticed that `#!hs ChildQuery`, a type synonym, is partially applied. That's because `#!hs Select.Query`, itself a type synonym, takes several arguments as described in the [module documentation on Pursuit](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Query). Let's walk through each one:
 
 ```hs
 type ChildQuery o item = Select.Query o item
@@ -271,7 +271,7 @@ dropdown st =
   ]
 ```
 
-From this, we can see that we need to use the state type from `Select` to drive our render function, not the state from our parent component. Will our function still work? Let's look at [`Select`'s state type in the module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:State) to see what we have available:
+From this, we can see that we need to use the state type from `Select` to drive our render function, not the state from our parent component. Will our function still work? Let's look at [`Select`'s state type in the module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:State) to see what we have available:
 
 ```hs
 type State item =
@@ -464,7 +464,7 @@ Error found in module Component:
 in type constructor Query
 ```
 
-This looks similar to the type error we got when we tried to just use `Select.Query` in a type synonym. We need to provide a `#!hs Type` to `#!hs HandleSelect`, but `#!hs Select.Message` is still awaiting 2 arguments, the first of which is *itself* awaiting an argument! Let's go look at the [module documentation for `Select.Message`](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Message).
+This looks similar to the type error we got when we tried to just use `Select.Query` in a type synonym. We need to provide a `#!hs Type` to `#!hs HandleSelect`, but `#!hs Select.Message` is still awaiting 2 arguments, the first of which is *itself* awaiting an argument! Let's go look at the [module documentation for `Select.Message`](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Message).
 
 ```hs
 data Message o item

--- a/docs/tutorials/dropdown.md
+++ b/docs/tutorials/dropdown.md
@@ -152,7 +152,7 @@ Error found:
 in type synonym ChildQuery
 ```
 
-The compiler has noticed that `#!hs ChildQuery`, a type synonym, is partially applied. That's because `#!hs Select.Query`, itself a type synonym, takes several arguments as described in the [module documentation on Pursuit](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Query). Let's walk through each one:
+The compiler has noticed that `#!hs ChildQuery`, a type synonym, is partially applied. That's because `#!hs Select.Query`, itself a type synonym, takes several arguments as described in the [module documentation on Pursuit](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Query). Let's walk through each one:
 
 ```hs
 type ChildQuery o item = Select.Query o item
@@ -271,7 +271,7 @@ dropdown st =
   ]
 ```
 
-From this, we can see that we need to use the state type from `Select` to drive our render function, not the state from our parent component. Will our function still work? Let's look at [`Select`'s state type in the module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:State) to see what we have available:
+From this, we can see that we need to use the state type from `Select` to drive our render function, not the state from our parent component. Will our function still work? Let's look at [`Select`'s state type in the module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:State) to see what we have available:
 
 ```hs
 type State item =
@@ -279,7 +279,7 @@ type State item =
   , search           :: String
   , debounceTime     :: Milliseconds
   , debouncer        :: Maybe Debouncer
-  , inputRef         :: RefLabel
+  , inputElement     :: Maybe HTMLElement
   , items            :: Array item
   , visibility       :: Visibility
   , highlightedIndex :: Maybe Int
@@ -398,13 +398,13 @@ dropdown childState =
   ]
 ```
 
-Finally, we can make sure that our button toggles the menu on and off, captures keyboard events, can be tabbed to, and all sorts of other stuff with the `#!hs setToggleProps` function. Note that this function takes the Select component's state as its first argument, which is necessary for Select to maintain a reference to the toggling element.
+Finally, we can make sure that our button toggles the menu on and off, captures keyboard events, can be tabbed to, and all sorts of other stuff with the `#!hs setToggleProps` function.
 
 ```hs
 dropdown childState =
   HH.div_
   [ HH.button
-    (Setters.setToggleProps childState [])
+    (Setters.setToggleProps [])
     [ HH.text $ fromMaybe "Click me to view some items" parentState.selectedItem ]
   , case childState.visibility of
       Select.Off -> HH.text ""
@@ -464,7 +464,7 @@ Error found in module Component:
 in type constructor Query
 ```
 
-This looks similar to the type error we got when we tried to just use `Select.Query` in a type synonym. We need to provide a `#!hs Type` to `#!hs HandleSelect`, but `#!hs Select.Message` is still awaiting 2 arguments, the first of which is *itself* awaiting an argument! Let's go look at the [module documentation for `Select.Message`](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Message).
+This looks similar to the type error we got when we tried to just use `Select.Query` in a type synonym. We need to provide a `#!hs Type` to `#!hs HandleSelect`, but `#!hs Select.Message` is still awaiting 2 arguments, the first of which is *itself* awaiting an argument! Let's go look at the [module documentation for `Select.Message`](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Message).
 
 ```hs
 data Message o item
@@ -650,7 +650,7 @@ If you'd like to use this component as a starting point from which to build your
           dropdown childState =
             HH.div_
             [ HH.button
-              (Setters.setToggleProps childState [])
+              (Setters.setToggleProps [])
               [ HH.text $ fromMaybe "Click me to view some items" parentState.selectedItem ]
             , case childState.visibility of
                 Select.Off -> HH.text ""

--- a/docs/tutorials/dropdown.md
+++ b/docs/tutorials/dropdown.md
@@ -152,7 +152,7 @@ Error found:
 in type synonym ChildQuery
 ```
 
-The compiler has noticed that `#!hs ChildQuery`, a type synonym, is partially applied. That's because `#!hs Select.Query`, itself a type synonym, takes several arguments as described in the [module documentation on Pursuit](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Query). Let's walk through each one:
+The compiler has noticed that `#!hs ChildQuery`, a type synonym, is partially applied. That's because `#!hs Select.Query`, itself a type synonym, takes several arguments as described in the [module documentation on Pursuit](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Query). Let's walk through each one:
 
 ```hs
 type ChildQuery o item = Select.Query o item
@@ -271,7 +271,7 @@ dropdown st =
   ]
 ```
 
-From this, we can see that we need to use the state type from `Select` to drive our render function, not the state from our parent component. Will our function still work? Let's look at [`Select`'s state type in the module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:State) to see what we have available:
+From this, we can see that we need to use the state type from `Select` to drive our render function, not the state from our parent component. Will our function still work? Let's look at [`Select`'s state type in the module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:State) to see what we have available:
 
 ```hs
 type State item =
@@ -279,7 +279,7 @@ type State item =
   , search           :: String
   , debounceTime     :: Milliseconds
   , debouncer        :: Maybe Debouncer
-  , inputElement     :: Maybe HTMLElement
+  , inputRef         :: RefLabel
   , items            :: Array item
   , visibility       :: Visibility
   , highlightedIndex :: Maybe Int
@@ -398,13 +398,13 @@ dropdown childState =
   ]
 ```
 
-Finally, we can make sure that our button toggles the menu on and off, captures keyboard events, can be tabbed to, and all sorts of other stuff with the `#!hs setToggleProps` function.
+Finally, we can make sure that our button toggles the menu on and off, captures keyboard events, can be tabbed to, and all sorts of other stuff with the `#!hs setToggleProps` function. Note that this function takes the Select component's state as its first argument, which is necessary for Select to maintain a reference to the toggling element.
 
 ```hs
 dropdown childState =
   HH.div_
   [ HH.button
-    (Setters.setToggleProps [])
+    (Setters.setToggleProps childState [])
     [ HH.text $ fromMaybe "Click me to view some items" parentState.selectedItem ]
   , case childState.visibility of
       Select.Off -> HH.text ""
@@ -464,7 +464,7 @@ Error found in module Component:
 in type constructor Query
 ```
 
-This looks similar to the type error we got when we tried to just use `Select.Query` in a type synonym. We need to provide a `#!hs Type` to `#!hs HandleSelect`, but `#!hs Select.Message` is still awaiting 2 arguments, the first of which is *itself* awaiting an argument! Let's go look at the [module documentation for `Select.Message`](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Message).
+This looks similar to the type error we got when we tried to just use `Select.Query` in a type synonym. We need to provide a `#!hs Type` to `#!hs HandleSelect`, but `#!hs Select.Message` is still awaiting 2 arguments, the first of which is *itself* awaiting an argument! Let's go look at the [module documentation for `Select.Message`](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Message).
 
 ```hs
 data Message o item
@@ -650,7 +650,7 @@ If you'd like to use this component as a starting point from which to build your
           dropdown childState =
             HH.div_
             [ HH.button
-              (Setters.setToggleProps [])
+              (Setters.setToggleProps childState [])
               [ HH.text $ fromMaybe "Click me to view some items" parentState.selectedItem ]
             , case childState.visibility of
                 Select.Off -> HH.text ""

--- a/docs/tutorials/typeahead.md
+++ b/docs/tutorials/typeahead.md
@@ -117,6 +117,7 @@ data QueryF o item a
   = Search String a
   | Highlight Target a
   | Select Int a
+  | CaptureRef ET.Event a
   | Focus Boolean a
   | Key KE.KeyboardEvent a
   | PreventClick ME.MouseEvent a
@@ -182,7 +183,7 @@ render st =
 	[ HH.slot unit Select.component ?input (HE.input HandleSelect) ]
 ```
 
-With that out of the way, we can turn to the component's input type. Here's what we're required to fill in, as per the [`Select` module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Input):
+With that out of the way, we can turn to the component's input type. Here's what we're required to fill in, as per the [`Select` module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Input):
 
 ```hs
 -- | Text-driven inputs will operate like a normal search-driven selection component.
@@ -272,7 +273,7 @@ type State item =
   , search           :: String
   , debounceTime     :: Milliseconds
   , debouncer        :: Maybe Debouncer
-  , inputRef         :: RefLabel
+  , inputElement     :: Maybe HTMLElement
   , items            :: Array item
   , visibility       :: Visibility
   , highlightedIndex :: Maybe Int
@@ -332,7 +333,7 @@ initialState = const
 
 Now that we've got a usable `#!hs State` type, let's turn to our queries. Queries are the computations available to the component, so they're the place where we ought to think about what the typeahead should *do*, rather than just how it should render.
 
-Just like `#!hs State`, when we write our own `#!hs Query` type on top of `Select`, we should consider what is already available in the component. As usual, we'll turn to the [module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:QueryF) to look at our available queries. I'd recommend scrolling through the available functions to get a glimpse of what `Select` offers, but we'll skip to the main points here.
+Just like `#!hs State`, when we write our own `#!hs Query` type on top of `Select`, we should consider what is already available in the component. As usual, we'll turn to the [module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:QueryF) to look at our available queries. I'd recommend scrolling through the available functions to get a glimpse of what `Select` offers, but we'll skip to the main points here.
 
 `Select` is going to manage all the keyboard events, text input, debouncing, moving the highlighted index, and so on. On top of that, we'll need to add some extra functionality: the ability to remove items that have already been selected, and the ability to fetch new items when the user performs a search. We'll at least need two queries to handle these two features.
 
@@ -582,7 +583,7 @@ Let's move on to the input field. This field needs to be controlled by `Select` 
 
 ```hs
 -- The text input field that will capture key events
-renderInput = HH.input ( Setters.setInputProps childState [] )
+renderInput = HH.input ( Setters.setInputProps [] )
 ```
 
 That's it! Now we have all the key events wired up for you. You could embed your own queries here, or add CSS, or whatever you want and the behavior will still work just fine.
@@ -766,7 +767,7 @@ If you'd like to use this component as a starting point from which to build your
               )
 
             -- The text input field that will capture key events
-            renderInput = HH.input ( Setters.setInputProps childState [] )
+            renderInput = HH.input ( Setters.setInputProps [] )
 
             -- The parent element holding the items  container
             renderContainer = case childState.visibility of

--- a/docs/tutorials/typeahead.md
+++ b/docs/tutorials/typeahead.md
@@ -331,7 +331,8 @@ initialState = const
 ### Query
 
 Now that we've got a usable `#!hs State` type, let's turn to our queries. Queries are the computations available to the component, so they're the place where we ought to think about what the typeahead should *do*, rather than just how it should render.
-3
+
+Just like `#!hs State`, when we write our own `#!hs Query` type on top of `Select`, we should consider what is already available in the component. As usual, we'll turn to the [module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:QueryF) to look at our available queries. I'd recommend scrolling through the available functions to get a glimpse of what `Select` offers, but we'll skip to the main points here.
 
 `Select` is going to manage all the keyboard events, text input, debouncing, moving the highlighted index, and so on. On top of that, we'll need to add some extra functionality: the ability to remove items that have already been selected, and the ability to fetch new items when the user performs a search. We'll at least need two queries to handle these two features.
 

--- a/docs/tutorials/typeahead.md
+++ b/docs/tutorials/typeahead.md
@@ -117,7 +117,6 @@ data QueryF o item a
   = Search String a
   | Highlight Target a
   | Select Int a
-  | CaptureRef ET.Event a
   | Focus Boolean a
   | Key KE.KeyboardEvent a
   | PreventClick ME.MouseEvent a
@@ -183,7 +182,7 @@ render st =
 	[ HH.slot unit Select.component ?input (HE.input HandleSelect) ]
 ```
 
-With that out of the way, we can turn to the component's input type. Here's what we're required to fill in, as per the [`Select` module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Input):
+With that out of the way, we can turn to the component's input type. Here's what we're required to fill in, as per the [`Select` module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Input):
 
 ```hs
 -- | Text-driven inputs will operate like a normal search-driven selection component.
@@ -273,7 +272,7 @@ type State item =
   , search           :: String
   , debounceTime     :: Milliseconds
   , debouncer        :: Maybe Debouncer
-  , inputElement     :: Maybe HTMLElement
+  , inputRef         :: RefLabel
   , items            :: Array item
   , visibility       :: Visibility
   , highlightedIndex :: Maybe Int
@@ -333,7 +332,7 @@ initialState = const
 
 Now that we've got a usable `#!hs State` type, let's turn to our queries. Queries are the computations available to the component, so they're the place where we ought to think about what the typeahead should *do*, rather than just how it should render.
 
-Just like `#!hs State`, when we write our own `#!hs Query` type on top of `Select`, we should consider what is already available in the component. As usual, we'll turn to the [module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:QueryF) to look at our available queries. I'd recommend scrolling through the available functions to get a glimpse of what `Select` offers, but we'll skip to the main points here.
+Just like `#!hs State`, when we write our own `#!hs Query` type on top of `Select`, we should consider what is already available in the component. As usual, we'll turn to the [module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:QueryF) to look at our available queries. I'd recommend scrolling through the available functions to get a glimpse of what `Select` offers, but we'll skip to the main points here.
 
 `Select` is going to manage all the keyboard events, text input, debouncing, moving the highlighted index, and so on. On top of that, we'll need to add some extra functionality: the ability to remove items that have already been selected, and the ability to fetch new items when the user performs a search. We'll at least need two queries to handle these two features.
 
@@ -583,7 +582,7 @@ Let's move on to the input field. This field needs to be controlled by `Select` 
 
 ```hs
 -- The text input field that will capture key events
-renderInput = HH.input ( Setters.setInputProps [] )
+renderInput = HH.input ( Setters.setInputProps childState [] )
 ```
 
 That's it! Now we have all the key events wired up for you. You could embed your own queries here, or add CSS, or whatever you want and the behavior will still work just fine.
@@ -767,7 +766,7 @@ If you'd like to use this component as a starting point from which to build your
               )
 
             -- The text input field that will capture key events
-            renderInput = HH.input ( Setters.setInputProps [] )
+            renderInput = HH.input ( Setters.setInputProps childState [] )
 
             -- The parent element holding the items  container
             renderContainer = case childState.visibility of

--- a/docs/tutorials/typeahead.md
+++ b/docs/tutorials/typeahead.md
@@ -117,7 +117,6 @@ data QueryF o item a
   = Search String a
   | Highlight Target a
   | Select Int a
-  | CaptureRef ET.Event a
   | Focus Boolean a
   | Key KE.KeyboardEvent a
   | PreventClick ME.MouseEvent a
@@ -183,7 +182,7 @@ render st =
 	[ HH.slot unit Select.component ?input (HE.input HandleSelect) ]
 ```
 
-With that out of the way, we can turn to the component's input type. Here's what we're required to fill in, as per the [`Select` module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:Input):
+With that out of the way, we can turn to the component's input type. Here's what we're required to fill in, as per the [`Select` module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/3.0.0/docs/Select#t:Input):
 
 ```hs
 -- | Text-driven inputs will operate like a normal search-driven selection component.
@@ -332,8 +331,7 @@ initialState = const
 ### Query
 
 Now that we've got a usable `#!hs State` type, let's turn to our queries. Queries are the computations available to the component, so they're the place where we ought to think about what the typeahead should *do*, rather than just how it should render.
-
-Just like `#!hs State`, when we write our own `#!hs Query` type on top of `Select`, we should consider what is already available in the component. As usual, we'll turn to the [module documentation](https://pursuit.purescript.org/packages/purescript-halogen-select/2.0.0/docs/Select#t:QueryF) to look at our available queries. I'd recommend scrolling through the available functions to get a glimpse of what `Select` offers, but we'll skip to the main points here.
+3
 
 `Select` is going to manage all the keyboard events, text input, debouncing, moving the highlighted index, and so on. On top of that, we'll need to add some extra functionality: the ability to remove items that have already been selected, and the ability to fetch new items when the user performs a search. We'll at least need two queries to handle these two features.
 

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -18,17 +18,8 @@ import Effect.Aff (Fiber, delay, error, forkAff, killFiber)
 import Effect.Aff.AVar (AVar)
 import Effect.Aff.AVar as AVar
 import Effect.Aff.Class (class MonadAff)
-import Halogen
-  ( Component
-  , ComponentDSL
-  , ComponentHTML
-  , RefLabel(..)
-  , component
-  , getHTMLElementRef
-  , liftAff
-  , liftEffect ) as H
+import Halogen as H
 import Halogen.HTML as HH
-import Halogen.Query.HalogenM (fork, raise) as H
 import Renderless.State (getState, modifyState_, modifyStore)
 import Web.Event.Event (preventDefault)
 import Web.HTML.HTMLElement (blur, focus)
@@ -260,7 +251,7 @@ component =
       , search: fromMaybe "" i.initialSearch
       , debounceTime: fromMaybe (Milliseconds 0.0) i.debounceTime
       , debouncer: Nothing
-      , inputRef: H.RefLabel "999z"
+      , inputRef: H.RefLabel "select-input"
       , items: i.items
       , highlightedIndex: Nothing
       , visibility: Off

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -197,7 +197,6 @@ type State item =
   , search           :: String
   , debounceTime     :: Milliseconds
   , debouncer        :: Maybe Debouncer
-  , inputRef         :: H.RefLabel
   , items            :: Array item
   , visibility       :: Visibility
   , highlightedIndex :: Maybe Int
@@ -251,7 +250,6 @@ component =
       , search: fromMaybe "" i.initialSearch
       , debounceTime: fromMaybe (Milliseconds 0.0) i.debounceTime
       , debouncer: Nothing
-      , inputRef: H.RefLabel "select-input"
       , items: i.items
       , highlightedIndex: Nothing
       , visibility: Off
@@ -331,7 +329,7 @@ component =
 
       Focus focusOrBlur a -> a <$ do
         st <- getState
-        inputElement <- H.getHTMLElementRef st.inputRef
+        inputElement <- H.getHTMLElementRef $ H.RefLabel "select-input"
         traverse_ (H.liftEffect <<< if focusOrBlur then focus else blur) inputElement
 
       Key ev a -> a <$ do
@@ -342,7 +340,7 @@ component =
           "ArrowDown" -> preventIt *> eval' (highlight Next)
           "Escape"    -> do
             st <- getState
-            inputElement <- H.getHTMLElementRef st.inputRef
+            inputElement <- H.getHTMLElementRef $ H.RefLabel "select-input"
             preventIt
             for_ inputElement (H.liftEffect <<< blur)
           "Enter"     -> do

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -328,7 +328,6 @@ component =
             \item -> H.raise (Selected item)
 
       Focus focusOrBlur a -> a <$ do
-        st <- getState
         inputElement <- H.getHTMLElementRef $ H.RefLabel "select-input"
         traverse_ (H.liftEffect <<< if focusOrBlur then focus else blur) inputElement
 
@@ -339,7 +338,6 @@ component =
           "ArrowUp"   -> preventIt *> eval' (highlight Prev)
           "ArrowDown" -> preventIt *> eval' (highlight Next)
           "Escape"    -> do
-            st <- getState
             inputElement <- H.getHTMLElementRef $ H.RefLabel "select-input"
             preventIt
             for_ inputElement (H.liftEffect <<< blur)

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -27,7 +27,7 @@ import Halogen
   , getHTMLElementRef
   , lifecycleComponent
   , liftAff
-  , liftEffect) as H
+  , liftEffect ) as H
 import Halogen.HTML as HH
 import Halogen.Query.HalogenM (fork, raise) as H
 import Renderless.State (getState, modifyState_, modifyStore)

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -42,8 +42,7 @@ setToggleProps
    . Array (HP.IProp (ToggleProps p) (Query o item Unit))
   -> Array (HP.IProp (ToggleProps p) (Query o item Unit))
 setToggleProps = flip (<>)
-  [ HE.onFocus \ev -> Just do
-      Select.setVisibility On
+  [ HE.onFocus $ Select.always $ Select.setVisibility On
   , HE.onMouseDown \ev -> Just do
       Select.preventClick ev
       Select.getVisibility >>= case _ of
@@ -85,8 +84,7 @@ setInputProps
    . Array (HP.IProp (InputProps p) (Query o item Unit))
   -> Array (HP.IProp (InputProps p) (Query o item Unit))
 setInputProps = flip (<>)
-  [ HE.onFocus \ev -> Just do
-      Select.setVisibility On
+  [ HE.onFocus $ Select.always $ Select.setVisibility On
   , HE.onKeyDown $ Just <<< Select.key
   , HE.onValueInput $ Just <<< Select.search
   , HE.onMouseDown $ Select.always $ Select.setVisibility On

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -38,14 +38,13 @@ type ToggleProps p =
 -- | ```
 setToggleProps
   :: ∀ o item p
-   . Array (HP.IProp (ToggleProps p) (Query o item Unit))
+   . Select.State item
   -> Array (HP.IProp (ToggleProps p) (Query o item Unit))
-setToggleProps = flip (<>)
+  -> Array (HP.IProp (ToggleProps p) (Query o item Unit))
+setToggleProps st = flip (<>)
   [ HE.onFocus \ev -> Just do
-      Select.captureRef $ FE.toEvent ev
       Select.setVisibility On
   , HE.onMouseDown \ev -> Just do
-      Select.captureRef $ ME.toEvent ev
       Select.preventClick ev
       Select.getVisibility >>= case _ of
         Select.On -> do
@@ -57,6 +56,7 @@ setToggleProps = flip (<>)
   , HE.onKeyDown $ Just <<< Select.key
   , HE.onBlur $ Select.always $ Select.setVisibility Off
   , HP.tabIndex 0
+  , HP.ref st.inputRef
   ]
 
 -- | The properties that must be supported by the HTML element that serves
@@ -82,17 +82,18 @@ type InputProps p =
 -- | ```
 setInputProps
   :: ∀ o item p
-   . Array (HP.IProp (InputProps p) (Query o item Unit))
+   . Select.State item
   -> Array (HP.IProp (InputProps p) (Query o item Unit))
-setInputProps = flip (<>)
+  -> Array (HP.IProp (InputProps p) (Query o item Unit))
+setInputProps st = flip (<>)
   [ HE.onFocus \ev -> Just do
-      Select.captureRef $ FE.toEvent ev
       Select.setVisibility On
   , HE.onKeyDown $ Just <<< Select.key
   , HE.onValueInput $ Just <<< Select.search
   , HE.onMouseDown $ Select.always $ Select.setVisibility On
   , HE.onBlur $ Select.always $ Select.setVisibility Off
   , HP.tabIndex 0
+  , HP.ref st.inputRef
   ]
 
 -- | The properties that must be supported by the HTML element that acts as a

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -6,15 +6,16 @@ module Select.Setters where
 
 import Prelude
 
-import Web.UIEvent.FocusEvent as FE
-import Web.UIEvent.MouseEvent as ME
-import Web.UIEvent.KeyboardEvent as KE
-import Web.Event.Event (Event)
 import Data.Maybe (Maybe(..))
+import Halogen (RefLabel(..)) as H
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Select (Query, Target(..), Visibility(..))
 import Select as Select
+import Web.Event.Event (Event)
+import Web.UIEvent.FocusEvent as FE
+import Web.UIEvent.KeyboardEvent as KE
+import Web.UIEvent.MouseEvent as ME
 
 -- | The properties that must be supported by the HTML element that serves
 -- | as a menu toggle. This should be used with toggle-driven `Select` components.
@@ -38,10 +39,9 @@ type ToggleProps p =
 -- | ```
 setToggleProps
   :: ∀ o item p
-   . Select.State item
+   . Array (HP.IProp (ToggleProps p) (Query o item Unit))
   -> Array (HP.IProp (ToggleProps p) (Query o item Unit))
-  -> Array (HP.IProp (ToggleProps p) (Query o item Unit))
-setToggleProps st = flip (<>)
+setToggleProps = flip (<>)
   [ HE.onFocus \ev -> Just do
       Select.setVisibility On
   , HE.onMouseDown \ev -> Just do
@@ -56,7 +56,7 @@ setToggleProps st = flip (<>)
   , HE.onKeyDown $ Just <<< Select.key
   , HE.onBlur $ Select.always $ Select.setVisibility Off
   , HP.tabIndex 0
-  , HP.ref st.inputRef
+  , HP.ref (H.RefLabel "select-input")
   ]
 
 -- | The properties that must be supported by the HTML element that serves
@@ -82,10 +82,9 @@ type InputProps p =
 -- | ```
 setInputProps
   :: ∀ o item p
-   . Select.State item
+   . Array (HP.IProp (InputProps p) (Query o item Unit))
   -> Array (HP.IProp (InputProps p) (Query o item Unit))
-  -> Array (HP.IProp (InputProps p) (Query o item Unit))
-setInputProps st = flip (<>)
+setInputProps = flip (<>)
   [ HE.onFocus \ev -> Just do
       Select.setVisibility On
   , HE.onKeyDown $ Just <<< Select.key
@@ -93,7 +92,7 @@ setInputProps st = flip (<>)
   , HE.onMouseDown $ Select.always $ Select.setVisibility On
   , HE.onBlur $ Select.always $ Select.setVisibility Off
   , HP.tabIndex 0
-  , HP.ref st.inputRef
+  , HP.ref (H.RefLabel "select-input")
   ]
 
 -- | The properties that must be supported by the HTML element that acts as a


### PR DESCRIPTION
## What does this pull request do?

This change improves the way that `Select` focuses or blurs its input or toggle element. Previously we would capture a reference to the element by relying on the focus event and storing that reference on state. This change makes `setInputProps` and `setToggleProps` set a `ref` on the element, which can be queried for in order to focus or blur.

## Other Notes:

As the commits suggest, I went through a few different iterations before arriving here. Knowing that these `RefLabel`s don't have to be unique, I think this is the cleanest approach. The `setToggleProps` and `setInputProps` signatures don't need to change, we can get rid of the `CaptureRef` query and relying on focus to get a reference to the element, and we can even get rid of the `inputElement` reference on the state. Plus it fits nicely into our existing expectation of the consumer, which is that they'll have to use those various `setProps` helpers to augment their properties; this is just another property that needs to go onto the element.