### PR TITLE
Fixed ordering of setters so that user event handlers override defaults

### DIFF
--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -41,7 +41,7 @@ setToggleProps
   :: ∀ o item p
    . Array (HP.IProp (ToggleProps p) (Query o item Unit))
   -> Array (HP.IProp (ToggleProps p) (Query o item Unit))
-setToggleProps = flip (<>)
+setToggleProps = (<>)
   [ HE.onFocus $ Select.always $ Select.setVisibility On
   , HE.onMouseDown \ev -> Just do
       Select.preventClick ev
@@ -83,7 +83,7 @@ setInputProps
   :: ∀ o item p
    . Array (HP.IProp (InputProps p) (Query o item Unit))
   -> Array (HP.IProp (InputProps p) (Query o item Unit))
-setInputProps = flip (<>)
+setInputProps = (<>)
   [ HE.onFocus $ Select.always $ Select.setVisibility On
   , HE.onKeyDown $ Just <<< Select.key
   , HE.onValueInput $ Just <<< Select.search
@@ -118,7 +118,7 @@ setItemProps
    . Int
   -> Array (HP.IProp (ItemProps p) (Query o item Unit))
   -> Array (HP.IProp (ItemProps p) (Query o item Unit))
-setItemProps index = flip (<>)
+setItemProps index = (<>)
   [ HE.onMouseDown \ev -> Just do
       Select.preventClick ev
       Select.select index
@@ -133,5 +133,5 @@ setContainerProps
   :: ∀ o item p
    . Array (HP.IProp (onMouseDown :: ME.MouseEvent | p) (Query o item Unit))
   -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | p) (Query o item Unit))
-setContainerProps = flip (<>)
+setContainerProps = (<>)
   [ HE.onMouseDown $ Just <<< Select.preventClick ]


### PR DESCRIPTION
## What does this pull request do?

Turns out the last `IProp` for an event handler wins. The reason we thought otherwise is that our lovely `appendIProps` function in Ocelot reverses the order of the props. But anyone not using Ocelot, or at least `appendIProps`, will not be able to override the default props here.

## Other Notes:

I have a [corresponding branch](https://github.com/citizennet/purescript-ocelot/compare/append-iprops-order#diff-5658dc7cefe70576ae75aa9b780dfe6b) in Ocelot that fixes `appendIProps`. Once this PR is approved and a new release tagged, I'll make a PR there as well.