### PR TITLE
Pass state to `setContainerProps` call

### DIFF
--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -66,7 +66,7 @@ spec = S.defaultSpec { render = render, handleMessage = handleMessage }
 
     renderContainer = whenElem (st.visibility == S.On) \_ ->
       HH.div
-        ( SS.setContainerProps [ class_ "Dropdown__container" ] )
+        ( SS.setContainerProps st [ class_ "Dropdown__container" ] )
         ( renderItem `mapWithIndex` st.items )
       where
       renderItem index item =


### PR DESCRIPTION
I was just trying this and got this as a compile error. Passing state fixes it so I suppose that's correct.