### PR TITLE
Expose `input` type in Select components and combine `spec` and `input` into `Select.component`

### DIFF
--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -32,6 +32,9 @@ type Input =
   , buttonLabel :: String
   }
 
+component :: H.Component HH.HTML S.Query' Input Message Aff
+component = S.component input spec
+
 input :: Input -> S.Input State
 input { items, buttonLabel } =
   { inputType: S.Toggle

--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -33,52 +33,54 @@ type Input =
   }
 
 component :: H.Component HH.HTML S.Query' Input Message Aff
-component = S.component input spec
-
-input :: Input -> S.Input State
-input { items, buttonLabel } =
-  { inputType: S.Toggle
-  , search: Nothing
-  , debounceTime: Nothing
-  , getItemCount: length <<< _.items
-  , items
-  , buttonLabel
-  , selection: Nothing
-  }
-
-spec :: S.Spec State (Const Void) Void () Message Aff
-spec = S.defaultSpec { render = render, handleMessage = handleMessage }
+component = S.component input $ S.defaultSpec
+    { render = render
+    , handleMessage = handleMessage
+    }
   where
-  handleMessage = case _ of
-    S.Selected ix -> do
-      st <- H.get
-      let selection = st.items !! ix
-      H.modify_ _ { selection = selection, visibility = S.Off }
-      H.raise $ SelectionChanged st.selection selection
-    _ -> pure unit
+    input :: Input -> S.Input State
+    input { items, buttonLabel } =
+      { inputType: S.Toggle
+      , search: Nothing
+      , debounceTime: Nothing
+      , getItemCount: length <<< _.items
+      , items
+      , buttonLabel
+      , selection: Nothing
+      }
 
-  render st =
-    HH.div
-      [ class_ "Dropdown" ]
-      [ renderToggle, renderContainer ]
-    where
-    renderToggle =
-      HH.button
-        ( SS.setToggleProps [ class_ "Dropdown__toggle" ] )
-        [ HH.text (fromMaybe st.buttonLabel st.selection) ]
+    handleMessage :: S.Message -> H.HalogenM (S.State State) S.Action' Message Aff Unit
+    handleMessage = case _ of
+      S.Selected ix -> do
+        st <- H.get
+        let selection = st.items !! ix
+        H.modify_ _ { selection = selection, visibility = S.Off }
+        H.raise $ SelectionChanged st.selection selection
+      _ -> pure unit
 
-    renderContainer = whenElem (st.visibility == S.On) \_ ->
+    render :: S.State State -> H.ComponentHTML S.Action' () Aff
+    render st =
       HH.div
-        ( SS.setContainerProps [ class_ "Dropdown__container" ] )
-        ( renderItem `mapWithIndex` st.items )
+        [ class_ "Dropdown" ]
+        [ renderToggle, renderContainer ]
       where
-      renderItem index item =
+      renderToggle =
+        HH.button
+          ( SS.setToggleProps [ class_ "Dropdown__toggle" ] )
+          [ HH.text (fromMaybe st.buttonLabel st.selection) ]
+
+      renderContainer = whenElem (st.visibility == S.On) \_ ->
         HH.div
-          ( SS.setItemProps index
-              [ classes_
-                  [ "Dropdown__item"
-                  , "Dropdown__item--highlighted" # guard (st.highlightedIndex == Just index)
-                  ]
-              ]
-          )
-          [ HH.text item ]
+          ( SS.setContainerProps [ class_ "Dropdown__container" ] )
+          ( renderItem `mapWithIndex` st.items )
+        where
+        renderItem index item =
+          HH.div
+            ( SS.setItemProps index
+                [ classes_
+                    [ "Dropdown__item"
+                    , "Dropdown__item--highlighted" # guard (st.highlightedIndex == Just index)
+                    ]
+                ]
+            )
+            [ HH.text item ]

--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -49,7 +49,7 @@ component = S.component input $ S.defaultSpec
       , selection: Nothing
       }
 
-    handleMessage :: S.Message -> H.HalogenM (S.State State) S.Action' Message Aff Unit
+    handleMessage :: S.Message -> H.HalogenM (S.State State) S.Action' () Message Aff Unit
     handleMessage = case _ of
       S.Selected ix -> do
         st <- H.get

--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -2,7 +2,6 @@ module Components.Dropdown where
 
 import Prelude
 
-import Data.Const (Const)
 import Effect.Aff (Aff)
 import Data.Array ((!!), mapWithIndex, length)
 import Data.Maybe (Maybe(..), fromMaybe)

--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -33,53 +33,53 @@ type Input =
 
 component :: H.Component HH.HTML S.Query' Input Message Aff
 component = S.component input $ S.defaultSpec
-    { render = render
-    , handleMessage = handleMessage
-    }
+  { render = render
+  , handleMessage = handleMessage
+  }
   where
-    input :: Input -> S.Input State
-    input { items, buttonLabel } =
-      { inputType: S.Toggle
-      , search: Nothing
-      , debounceTime: Nothing
-      , getItemCount: length <<< _.items
-      , items
-      , buttonLabel
-      , selection: Nothing
-      }
+  input :: Input -> S.Input State
+  input { items, buttonLabel } =
+    { inputType: S.Toggle
+    , search: Nothing
+    , debounceTime: Nothing
+    , getItemCount: length <<< _.items
+    , items
+    , buttonLabel
+    , selection: Nothing
+    }
 
-    handleMessage :: S.Message -> H.HalogenM (S.State State) S.Action' () Message Aff Unit
-    handleMessage = case _ of
-      S.Selected ix -> do
-        st <- H.get
-        let selection = st.items !! ix
-        H.modify_ _ { selection = selection, visibility = S.Off }
-        H.raise $ SelectionChanged st.selection selection
-      _ -> pure unit
+  handleMessage :: S.Message -> H.HalogenM (S.State State) S.Action' () Message Aff Unit
+  handleMessage = case _ of
+    S.Selected ix -> do
+      st <- H.get
+      let selection = st.items !! ix
+      H.modify_ _ { selection = selection, visibility = S.Off }
+      H.raise $ SelectionChanged st.selection selection
+    _ -> pure unit
 
-    render :: S.State State -> H.ComponentHTML S.Action' () Aff
-    render st =
+  render :: S.State State -> H.ComponentHTML S.Action' () Aff
+  render st =
+    HH.div
+      [ class_ "Dropdown" ]
+      [ renderToggle, renderContainer ]
+    where
+    renderToggle =
+      HH.button
+        ( SS.setToggleProps [ class_ "Dropdown__toggle" ] )
+        [ HH.text (fromMaybe st.buttonLabel st.selection) ]
+
+    renderContainer = whenElem (st.visibility == S.On) \_ ->
       HH.div
-        [ class_ "Dropdown" ]
-        [ renderToggle, renderContainer ]
+        ( SS.setContainerProps [ class_ "Dropdown__container" ] )
+        ( renderItem `mapWithIndex` st.items )
       where
-      renderToggle =
-        HH.button
-          ( SS.setToggleProps [ class_ "Dropdown__toggle" ] )
-          [ HH.text (fromMaybe st.buttonLabel st.selection) ]
-
-      renderContainer = whenElem (st.visibility == S.On) \_ ->
+      renderItem index item =
         HH.div
-          ( SS.setContainerProps [ class_ "Dropdown__container" ] )
-          ( renderItem `mapWithIndex` st.items )
-        where
-        renderItem index item =
-          HH.div
-            ( SS.setItemProps index
-                [ classes_
-                    [ "Dropdown__item"
-                    , "Dropdown__item--highlighted" # guard (st.highlightedIndex == Just index)
-                    ]
-                ]
-            )
-            [ HH.text item ]
+          ( SS.setItemProps index
+              [ classes_
+                  [ "Dropdown__item"
+                  , "Dropdown__item--highlighted" # guard (st.highlightedIndex == Just index)
+                  ]
+              ]
+          )
+          [ HH.text item ]

--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -18,7 +18,7 @@ type Slot =
 
 type State =
   ( items :: Array String
-  , selection :: Maybe String 
+  , selection :: Maybe String
   , buttonLabel :: String
   )
 
@@ -32,7 +32,7 @@ type Input =
   , buttonLabel :: String
   }
 
-input :: Input -> S.Input State 
+input :: Input -> S.Input State
 input { items, buttonLabel } =
   { inputType: S.Toggle
   , search: Nothing
@@ -54,8 +54,8 @@ spec = S.defaultSpec { render = render, handleMessage = handleMessage }
       H.raise $ SelectionChanged st.selection selection
     _ -> pure unit
 
-  render st = 
-    HH.div 
+  render st =
+    HH.div
       [ class_ "Dropdown" ]
       [ renderToggle, renderContainer ]
     where
@@ -70,13 +70,12 @@ spec = S.defaultSpec { render = render, handleMessage = handleMessage }
         ( renderItem `mapWithIndex` st.items )
       where
       renderItem index item =
-        HH.div 
-          ( SS.setItemProps index 
-              [ classes_ 
+        HH.div
+          ( SS.setItemProps index
+              [ classes_
                   [ "Dropdown__item"
                   , "Dropdown__item--highlighted" # guard (st.highlightedIndex == Just index)
                   ]
               ]
-          ) 
+          )
           [ HH.text item ]
-

--- a/examples/Components/Dropdown.purs
+++ b/examples/Components/Dropdown.purs
@@ -34,7 +34,7 @@ type Input =
 component :: H.Component HH.HTML S.Query' Input Message Aff
 component = S.component input $ S.defaultSpec
   { render = render
-  , handleMessage = handleMessage
+  , handleEvent = handleEvent
   }
   where
   input :: Input -> S.Input State
@@ -48,8 +48,8 @@ component = S.component input $ S.defaultSpec
     , selection: Nothing
     }
 
-  handleMessage :: S.Message -> H.HalogenM (S.State State) S.Action' () Message Aff Unit
-  handleMessage = case _ of
+  handleEvent :: S.Event -> H.HalogenM (S.State State) S.Action' () Message Aff Unit
+  handleEvent = case _ of
     S.Selected ix -> do
       st <- H.get
       let selection = st.items !! ix

--- a/examples/Components/Typeahead.purs
+++ b/examples/Components/Typeahead.purs
@@ -51,7 +51,7 @@ component = S.component (const input) $ S.defaultSpec
   { render = render
   , handleAction = handleAction
   , handleQuery = handleQuery
-  , handleMessage = handleMessage
+  , handleEvent = handleEvent
   }
   where
   -- this typeahead will be opaque; users can just use this pre-built
@@ -66,10 +66,10 @@ component = S.component (const input) $ S.defaultSpec
     , available: RD.NotAsked
     }
 
-  handleMessage
-    :: S.Message
+  handleEvent
+    :: S.Event
     -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
-  handleMessage = case _ of
+  handleEvent = case _ of
     S.Selected ix -> do
       st <- H.get
       for_ st.available \arr ->

--- a/examples/Components/Typeahead.purs
+++ b/examples/Components/Typeahead.purs
@@ -46,6 +46,9 @@ data Message
 type ChildSlots =
   ( dropdown :: D.Slot Unit )
 
+component :: H.Component HH.HTML (S.Query Query ChildSlots) Unit Message Aff
+component = S.component (const input) spec
+
 -- this typeahead will be opaque; users can just use this pre-built
 -- input instead of the usual select one.
 input :: S.Input State
@@ -162,7 +165,7 @@ spec = S.defaultSpec
       ]
 
     renderDropdown = whenElem (st.visibility == S.On) \_ ->
-      HH.slot _dropdown unit (S.component D.spec) (D.input dropdownInput) handler
+      HH.slot _dropdown unit D.component dropdownInput handler
       where
       _dropdown = SProxy :: SProxy "dropdown"
       handler msg = Just $ S.Action $ HandleDropdown msg

--- a/examples/Components/Typeahead.purs
+++ b/examples/Components/Typeahead.purs
@@ -48,161 +48,161 @@ type ChildSlots =
 
 component :: H.Component HH.HTML (S.Query Query ChildSlots) Unit Message Aff
 component = S.component (const input) $ S.defaultSpec
-    { render = render
-    , handleAction = handleAction
-    , handleQuery = handleQuery
-    , handleMessage = handleMessage
-    }
+  { render = render
+  , handleAction = handleAction
+  , handleQuery = handleQuery
+  , handleMessage = handleMessage
+  }
   where
-    -- this typeahead will be opaque; users can just use this pre-built
-    -- input instead of the usual select one.
-    input :: S.Input State
-    input =
-      { inputType: S.Text
-      , debounceTime: Just (Milliseconds 300.0)
-      , search: Nothing
-      , getItemCount: maybe 0 length <<< RD.toMaybe <<< _.available
-      , selections: []
-      , available: RD.NotAsked
-      }
+  -- this typeahead will be opaque; users can just use this pre-built
+  -- input instead of the usual select one.
+  input :: S.Input State
+  input =
+    { inputType: S.Text
+    , debounceTime: Just (Milliseconds 300.0)
+    , search: Nothing
+    , getItemCount: maybe 0 length <<< RD.toMaybe <<< _.available
+    , selections: []
+    , available: RD.NotAsked
+    }
 
-    handleMessage
-      :: S.Message
-      -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
-    handleMessage = case _ of
-      S.Selected ix -> do
+  handleMessage
+    :: S.Message
+    -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
+  handleMessage = case _ of
+    S.Selected ix -> do
+      st <- H.get
+      for_ st.available \arr ->
+        for_ (arr !! ix) \item -> do
+          let newSelections = item : st.selections
+          H.modify_ _
+            { selections = item : st.selections
+            , available = RD.Success (filter (_ /= item) arr)
+            , search = ""
+            }
+          H.raise $ SelectionsChanged newSelections
+    S.Searched str -> do
+      st <- H.get
+      -- we'll use an external api to search locations
+      H.modify_ _ { available = RD.Loading }
+      items <- H.liftAff $ searchLocations str
+      H.modify_ _ { available = items <#> \xs -> difference xs st.selections }
+    _ -> pure unit
+
+  -- You can remove all type signatures except for this one; we need to tell the
+  -- compiler about the `a` type variable. The minimal necessary signature is below.
+  handleQuery :: forall a. Query a -> H.HalogenM _ _ _ _ _ (Maybe a)
+  handleQuery = case _ of
+    GetSelections reply -> do
+       st <- H.get
+       pure $ Just $ reply st.selections
+
+  handleAction
+    :: Action
+    -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
+  handleAction = case _ of
+    Remove item -> do
+      st <- H.get
+      let newSelections = filter (_ /= item) st.selections
+      H.modify_ _ { selections = newSelections }
+      H.raise $ ItemRemoved item
+    HandleDropdown msg -> case msg of
+      D.SelectionChanged oldSelection newSelection -> do
         st <- H.get
-        for_ st.available \arr ->
-          for_ (arr !! ix) \item -> do
-            let newSelections = item : st.selections
-            H.modify_ _
-              { selections = item : st.selections
-              , available = RD.Success (filter (_ /= item) arr)
-              , search = ""
-              }
-            H.raise $ SelectionsChanged newSelections
-      S.Searched str -> do
-        st <- H.get
-        -- we'll use an external api to search locations
-        H.modify_ _ { available = RD.Loading }
-        items <- H.liftAff $ searchLocations str
-        H.modify_ _ { available = items <#> \xs -> difference xs st.selections }
-      _ -> pure unit
+        let
+          mkLocation str = { name: "User Added: " <> str, population: "1" }
+          newSelections = case oldSelection, newSelection of
+            Nothing, Nothing ->
+              Nothing
+            Nothing, Just str ->
+              Just (mkLocation str : st.selections)
+            Just str, Nothing ->
+              Just (filter (_ /= mkLocation str) st.selections)
+            Just old, Just new ->
+              Just (mkLocation new : (filter (_ /= mkLocation old) st.selections))
+        for_ newSelections \selections ->
+          H.modify_ _ { selections = selections }
 
-    -- You can remove all type signatures except for this one; we need to tell the
-    -- compiler about the `a` type variable. The minimal necessary signature is below.
-    handleQuery :: forall a. Query a -> H.HalogenM _ _ _ _ _ (Maybe a)
-    handleQuery = case _ of
-      GetSelections reply -> do
-         st <- H.get
-         pure $ Just $ reply st.selections
+  render :: S.State State -> H.ComponentHTML (S.Action Action) ChildSlots Aff
+  render st =
+    HH.div
+      [ class_ "Typeahead" ]
+      [ renderSelections, renderInput, renderDropdown, renderContainer ]
+    where
+    hasSelections = length st.selections > 0
 
-    handleAction
-      :: Action
-      -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
-    handleAction = case _ of
-      Remove item -> do
-        st <- H.get
-        let newSelections = filter (_ /= item) st.selections
-        H.modify_ _ { selections = newSelections }
-        H.raise $ ItemRemoved item
-      HandleDropdown msg -> case msg of
-        D.SelectionChanged oldSelection newSelection -> do
-          st <- H.get
-          let
-            mkLocation str = { name: "User Added: " <> str, population: "1" }
-            newSelections = case oldSelection, newSelection of
-              Nothing, Nothing ->
-                Nothing
-              Nothing, Just str ->
-                Just (mkLocation str : st.selections)
-              Just str, Nothing ->
-                Just (filter (_ /= mkLocation str) st.selections)
-              Just old, Just new ->
-                Just (mkLocation new : (filter (_ /= mkLocation old) st.selections))
-          for_ newSelections \selections ->
-            H.modify_ _ { selections = selections }
-
-    render :: S.State State -> H.ComponentHTML (S.Action Action) ChildSlots Aff
-    render st =
+    renderSelections = whenElem hasSelections \_ ->
       HH.div
-        [ class_ "Typeahead" ]
-        [ renderSelections, renderInput, renderDropdown, renderContainer ]
+        [ class_ "Typeahead__selections" ]
+        (renderSelectedItem <$> st.selections)
       where
-      hasSelections = length st.selections > 0
-
-      renderSelections = whenElem hasSelections \_ ->
+      renderSelectedItem item =
         HH.div
-          [ class_ "Typeahead__selections" ]
-          (renderSelectedItem <$> st.selections)
-        where
-        renderSelectedItem item =
-          HH.div
-            [ class_ "Typeahead__item--selected Location" ]
-            [ HH.span
-                [ class_ "Location__name" ]
-                [ HH.text item.name ]
-            , closeButton item
-            ]
+          [ class_ "Typeahead__item--selected Location" ]
+          [ HH.span
+              [ class_ "Location__name" ]
+              [ HH.text item.name ]
+          , closeButton item
+          ]
 
-        closeButton item =
-          HH.span
-            [ class_ "Location__closeButton"
-            , HE.onClick \_ -> Just $ S.Action $ Remove item
-            ]
-            [ HH.text "×" ]
+      closeButton item =
+        HH.span
+          [ class_ "Location__closeButton"
+          , HE.onClick \_ -> Just $ S.Action $ Remove item
+          ]
+          [ HH.text "×" ]
 
-      renderInput = HH.input $ SS.setInputProps
-        [ classes_
-            [ "Typeahead__input"
-            , "Typeahead__input--selections" # guard hasSelections
-            , "Typeahead__input--active" # guard (st.visibility == S.On)
-            ]
-        , HP.placeholder "Type to search..."
-        ]
+    renderInput = HH.input $ SS.setInputProps
+      [ classes_
+          [ "Typeahead__input"
+          , "Typeahead__input--selections" # guard hasSelections
+          , "Typeahead__input--active" # guard (st.visibility == S.On)
+          ]
+      , HP.placeholder "Type to search..."
+      ]
 
-      renderDropdown = whenElem (st.visibility == S.On) \_ ->
-        HH.slot _dropdown unit D.component dropdownInput handler
-        where
-        _dropdown = SProxy :: SProxy "dropdown"
-        handler msg = Just $ S.Action $ HandleDropdown msg
-        dropdownInput = { items: [ "Earth", "Mars" ], buttonLabel: "Human Planets" }
+    renderDropdown = whenElem (st.visibility == S.On) \_ ->
+      HH.slot _dropdown unit D.component dropdownInput handler
+      where
+      _dropdown = SProxy :: SProxy "dropdown"
+      handler msg = Just $ S.Action $ HandleDropdown msg
+      dropdownInput = { items: [ "Earth", "Mars" ], buttonLabel: "Human Planets" }
 
-      renderContainer = whenElem (st.visibility == S.On) \_ ->
+    renderContainer = whenElem (st.visibility == S.On) \_ ->
+      HH.div
+        (SS.setContainerProps
+          [ classes_
+              [ "Typeahead__container"
+              , "Typeahead__container--hasItems" # guard hasItems
+              ]
+          ]
+        )
+        renderItems
+      where
+      hasItems = maybe false (not <<< null) (RD.toMaybe st.available)
+      renderItems = do
+        let renderMsg msg = [ HH.span_ [ HH.text msg ] ]
+        case st.available of
+          RD.NotAsked -> renderMsg "No search performed..."
+          RD.Loading -> renderMsg "Loading..."
+          RD.Failure e -> renderMsg e
+          RD.Success available
+            | hasItems -> renderItem `mapWithIndex` available
+            | otherwise -> renderMsg "No results found"
+
+      renderItem index { name, population } =
         HH.div
-          (SS.setContainerProps
-            [ classes_
-                [ "Typeahead__container"
-                , "Typeahead__container--hasItems" # guard hasItems
-                ]
-            ]
-          )
-          renderItems
+          (SS.setItemProps index [ classes_ [ base, highlight, "Location" ] ])
+          [ HH.span
+              [ class_ "Location__name" ]
+              [ HH.text name ]
+          , HH.span
+              [ class_ "Location__population" ]
+              [ HH.text population ]
+          ]
         where
-        hasItems = maybe false (not <<< null) (RD.toMaybe st.available)
-        renderItems = do
-          let renderMsg msg = [ HH.span_ [ HH.text msg ] ]
-          case st.available of
-            RD.NotAsked -> renderMsg "No search performed..."
-            RD.Loading -> renderMsg "Loading..."
-            RD.Failure e -> renderMsg e
-            RD.Success available
-              | hasItems -> renderItem `mapWithIndex` available
-              | otherwise -> renderMsg "No results found"
-
-        renderItem index { name, population } =
-          HH.div
-            (SS.setItemProps index [ classes_ [ base, highlight, "Location" ] ])
-            [ HH.span
-                [ class_ "Location__name" ]
-                [ HH.text name ]
-            , HH.span
-                [ class_ "Location__population" ]
-                [ HH.text population ]
-            ]
-          where
-          base = "Typeahead__item"
-          highlight = "Typeahead__item--highlighted" # guard (st.highlightedIndex == Just index)
+        base = "Typeahead__item"
+        highlight = "Typeahead__item--highlighted" # guard (st.highlightedIndex == Just index)
 
 
 -- Let's make this typeahead async.

--- a/examples/Components/Typeahead.purs
+++ b/examples/Components/Typeahead.purs
@@ -47,165 +47,162 @@ type ChildSlots =
   ( dropdown :: D.Slot Unit )
 
 component :: H.Component HH.HTML (S.Query Query ChildSlots) Unit Message Aff
-component = S.component (const input) spec
-
--- this typeahead will be opaque; users can just use this pre-built
--- input instead of the usual select one.
-input :: S.Input State
-input =
-  { inputType: S.Text
-  , debounceTime: Just (Milliseconds 300.0)
-  , search: Nothing
-  , getItemCount: maybe 0 length <<< RD.toMaybe <<< _.available
-  , selections: []
-  , available: RD.NotAsked
-  }
-
-spec :: S.Spec State Query Action ChildSlots Message Aff
-spec = S.defaultSpec
-  { render = render
-  , handleAction = handleAction
-  , handleQuery = handleQuery
-  , handleMessage = handleMessage
-  }
+component = S.component (const input) $ S.defaultSpec
+    { render = render
+    , handleAction = handleAction
+    , handleQuery = handleQuery
+    , handleMessage = handleMessage
+    }
   where
-  handleMessage
-    :: S.Message
-    -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
-  handleMessage = case _ of
-    S.Selected ix -> do
-      st <- H.get
-      for_ st.available \arr ->
-        for_ (arr !! ix) \item -> do
-          let newSelections = item : st.selections
-          H.modify_ _
-            { selections = item : st.selections
-            , available = RD.Success (filter (_ /= item) arr)
-            , search = ""
-            }
-          H.raise $ SelectionsChanged newSelections
-    S.Searched str -> do
-      st <- H.get
-      -- we'll use an external api to search locations
-      H.modify_ _ { available = RD.Loading }
-      items <- H.liftAff $ searchLocations str
-      H.modify_ _ { available = items <#> \xs -> difference xs st.selections }
-    _ -> pure unit
+    -- this typeahead will be opaque; users can just use this pre-built
+    -- input instead of the usual select one.
+    input :: S.Input State
+    input =
+      { inputType: S.Text
+      , debounceTime: Just (Milliseconds 300.0)
+      , search: Nothing
+      , getItemCount: maybe 0 length <<< RD.toMaybe <<< _.available
+      , selections: []
+      , available: RD.NotAsked
+      }
 
-  -- You can remove all type signatures except for this one; we need to tell the
-  -- compiler about the `a` type variable. The minimal necessary signature is below.
-  handleQuery :: forall a. Query a -> H.HalogenM _ _ _ _ _ (Maybe a)
-  handleQuery = case _ of
-    GetSelections reply -> do
-       st <- H.get
-       pure $ Just $ reply st.selections
-
-  handleAction
-    :: Action
-    -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
-  handleAction = case _ of
-    Remove item -> do
-      st <- H.get
-      let newSelections = filter (_ /= item) st.selections
-      H.modify_ _ { selections = newSelections }
-      H.raise $ ItemRemoved item
-    HandleDropdown msg -> case msg of
-      D.SelectionChanged oldSelection newSelection -> do
+    handleMessage
+      :: S.Message
+      -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
+    handleMessage = case _ of
+      S.Selected ix -> do
         st <- H.get
-        let
-          mkLocation str = { name: "User Added: " <> str, population: "1" }
-          newSelections = case oldSelection, newSelection of
-            Nothing, Nothing ->
-              Nothing
-            Nothing, Just str ->
-              Just (mkLocation str : st.selections)
-            Just str, Nothing ->
-              Just (filter (_ /= mkLocation str) st.selections)
-            Just old, Just new ->
-              Just (mkLocation new : (filter (_ /= mkLocation old) st.selections))
-        for_ newSelections \selections ->
-          H.modify_ _ { selections = selections }
+        for_ st.available \arr ->
+          for_ (arr !! ix) \item -> do
+            let newSelections = item : st.selections
+            H.modify_ _
+              { selections = item : st.selections
+              , available = RD.Success (filter (_ /= item) arr)
+              , search = ""
+              }
+            H.raise $ SelectionsChanged newSelections
+      S.Searched str -> do
+        st <- H.get
+        -- we'll use an external api to search locations
+        H.modify_ _ { available = RD.Loading }
+        items <- H.liftAff $ searchLocations str
+        H.modify_ _ { available = items <#> \xs -> difference xs st.selections }
+      _ -> pure unit
 
-  render :: S.State State -> H.ComponentHTML (S.Action Action) ChildSlots Aff
-  render st =
-    HH.div
-      [ class_ "Typeahead" ]
-      [ renderSelections, renderInput, renderDropdown, renderContainer ]
-    where
-    hasSelections = length st.selections > 0
+    -- You can remove all type signatures except for this one; we need to tell the
+    -- compiler about the `a` type variable. The minimal necessary signature is below.
+    handleQuery :: forall a. Query a -> H.HalogenM _ _ _ _ _ (Maybe a)
+    handleQuery = case _ of
+      GetSelections reply -> do
+         st <- H.get
+         pure $ Just $ reply st.selections
 
-    renderSelections = whenElem hasSelections \_ ->
+    handleAction
+      :: Action
+      -> H.HalogenM (S.State State) (S.Action Action) ChildSlots Message Aff Unit
+    handleAction = case _ of
+      Remove item -> do
+        st <- H.get
+        let newSelections = filter (_ /= item) st.selections
+        H.modify_ _ { selections = newSelections }
+        H.raise $ ItemRemoved item
+      HandleDropdown msg -> case msg of
+        D.SelectionChanged oldSelection newSelection -> do
+          st <- H.get
+          let
+            mkLocation str = { name: "User Added: " <> str, population: "1" }
+            newSelections = case oldSelection, newSelection of
+              Nothing, Nothing ->
+                Nothing
+              Nothing, Just str ->
+                Just (mkLocation str : st.selections)
+              Just str, Nothing ->
+                Just (filter (_ /= mkLocation str) st.selections)
+              Just old, Just new ->
+                Just (mkLocation new : (filter (_ /= mkLocation old) st.selections))
+          for_ newSelections \selections ->
+            H.modify_ _ { selections = selections }
+
+    render :: S.State State -> H.ComponentHTML (S.Action Action) ChildSlots Aff
+    render st =
       HH.div
-        [ class_ "Typeahead__selections" ]
-        (renderSelectedItem <$> st.selections)
+        [ class_ "Typeahead" ]
+        [ renderSelections, renderInput, renderDropdown, renderContainer ]
       where
-      renderSelectedItem item =
+      hasSelections = length st.selections > 0
+
+      renderSelections = whenElem hasSelections \_ ->
         HH.div
-          [ class_ "Typeahead__item--selected Location" ]
-          [ HH.span
-              [ class_ "Location__name" ]
-              [ HH.text item.name ]
-          , closeButton item
-          ]
-
-      closeButton item =
-        HH.span
-          [ class_ "Location__closeButton"
-          , HE.onClick \_ -> Just $ S.Action $ Remove item
-          ]
-          [ HH.text "×" ]
-
-    renderInput = HH.input $ SS.setInputProps
-      [ classes_
-          [ "Typeahead__input"
-          , "Typeahead__input--selections" # guard hasSelections
-          , "Typeahead__input--active" # guard (st.visibility == S.On)
-          ]
-      , HP.placeholder "Type to search..."
-      ]
-
-    renderDropdown = whenElem (st.visibility == S.On) \_ ->
-      HH.slot _dropdown unit D.component dropdownInput handler
-      where
-      _dropdown = SProxy :: SProxy "dropdown"
-      handler msg = Just $ S.Action $ HandleDropdown msg
-      dropdownInput = { items: [ "Earth", "Mars" ], buttonLabel: "Human Planets" }
-
-    renderContainer = whenElem (st.visibility == S.On) \_ ->
-      HH.div
-        (SS.setContainerProps
-          [ classes_
-              [ "Typeahead__container"
-              , "Typeahead__container--hasItems" # guard hasItems
-              ]
-          ]
-        )
-        renderItems
-      where
-      hasItems = maybe false (not <<< null) (RD.toMaybe st.available)
-      renderItems = do
-        let renderMsg msg = [ HH.span_ [ HH.text msg ] ]
-        case st.available of
-          RD.NotAsked -> renderMsg "No search performed..."
-          RD.Loading -> renderMsg "Loading..."
-          RD.Failure e -> renderMsg e
-          RD.Success available
-            | hasItems -> renderItem `mapWithIndex` available
-            | otherwise -> renderMsg "No results found"
-
-      renderItem index { name, population } =
-        HH.div
-          (SS.setItemProps index [ classes_ [ base, highlight, "Location" ] ])
-          [ HH.span
-              [ class_ "Location__name" ]
-              [ HH.text name ]
-          , HH.span
-              [ class_ "Location__population" ]
-              [ HH.text population ]
-          ]
+          [ class_ "Typeahead__selections" ]
+          (renderSelectedItem <$> st.selections)
         where
-        base = "Typeahead__item"
-        highlight = "Typeahead__item--highlighted" # guard (st.highlightedIndex == Just index)
+        renderSelectedItem item =
+          HH.div
+            [ class_ "Typeahead__item--selected Location" ]
+            [ HH.span
+                [ class_ "Location__name" ]
+                [ HH.text item.name ]
+            , closeButton item
+            ]
+
+        closeButton item =
+          HH.span
+            [ class_ "Location__closeButton"
+            , HE.onClick \_ -> Just $ S.Action $ Remove item
+            ]
+            [ HH.text "×" ]
+
+      renderInput = HH.input $ SS.setInputProps
+        [ classes_
+            [ "Typeahead__input"
+            , "Typeahead__input--selections" # guard hasSelections
+            , "Typeahead__input--active" # guard (st.visibility == S.On)
+            ]
+        , HP.placeholder "Type to search..."
+        ]
+
+      renderDropdown = whenElem (st.visibility == S.On) \_ ->
+        HH.slot _dropdown unit D.component dropdownInput handler
+        where
+        _dropdown = SProxy :: SProxy "dropdown"
+        handler msg = Just $ S.Action $ HandleDropdown msg
+        dropdownInput = { items: [ "Earth", "Mars" ], buttonLabel: "Human Planets" }
+
+      renderContainer = whenElem (st.visibility == S.On) \_ ->
+        HH.div
+          (SS.setContainerProps
+            [ classes_
+                [ "Typeahead__container"
+                , "Typeahead__container--hasItems" # guard hasItems
+                ]
+            ]
+          )
+          renderItems
+        where
+        hasItems = maybe false (not <<< null) (RD.toMaybe st.available)
+        renderItems = do
+          let renderMsg msg = [ HH.span_ [ HH.text msg ] ]
+          case st.available of
+            RD.NotAsked -> renderMsg "No search performed..."
+            RD.Loading -> renderMsg "Loading..."
+            RD.Failure e -> renderMsg e
+            RD.Success available
+              | hasItems -> renderItem `mapWithIndex` available
+              | otherwise -> renderMsg "No results found"
+
+        renderItem index { name, population } =
+          HH.div
+            (SS.setItemProps index [ classes_ [ base, highlight, "Location" ] ])
+            [ HH.span
+                [ class_ "Location__name" ]
+                [ HH.text name ]
+            , HH.span
+                [ class_ "Location__population" ]
+                [ HH.text population ]
+            ]
+          where
+          base = "Typeahead__item"
+          highlight = "Typeahead__item--highlighted" # guard (st.highlightedIndex == Just index)
 
 
 -- Let's make this typeahead async.

--- a/examples/Internal/CSS.purs
+++ b/examples/Internal/CSS.purs
@@ -13,4 +13,3 @@ classes_ = HP.classes <<< map HH.ClassName
 
 whenElem :: forall p i. Boolean -> (Unit -> HH.HTML i p) -> HH.HTML i p
 whenElem cond render = if cond then render unit else HH.text ""
-

--- a/examples/Internal/RemoteData.purs
+++ b/examples/Internal/RemoteData.purs
@@ -1,4 +1,4 @@
--- | Copied over from 
+-- | Copied over from
 -- | https://github.com/krisajenkins/purescript-remotedata
 -- |
 -- | due to dependency conflicts
@@ -42,4 +42,3 @@ fromMaybe (Just value) = Success value
 fromEither :: forall e a. Either e a -> RemoteData e a
 fromEither (Left err) = Failure err
 fromEither (Right value) = Success value
-

--- a/examples/Main.purs
+++ b/examples/Main.purs
@@ -19,7 +19,6 @@ import Halogen.Aff as HA
 import Halogen.HTML as HH
 import Halogen.VDom.Driver (runUI)
 import Internal.Proxy (ProxyS, proxy)
-import Select as Select
 import Web.DOM.Element (getAttribute)
 import Web.DOM.NodeList (toArray)
 import Web.DOM.ParentNode (QuerySelector(..), querySelectorAll)

--- a/examples/Main.purs
+++ b/examples/Main.purs
@@ -48,7 +48,7 @@ type Components
 routes :: Components
 routes = M.fromFoldable
   [ Tuple "typeahead" $ proxy typeahead
-  , Tuple "dropdown" $ proxy dropdown 
+  , Tuple "dropdown" $ proxy dropdown
   ]
 
 app :: H.Component HH.HTML (Const Void) String Void Aff
@@ -74,9 +74,9 @@ selectElements
   :: { query :: QuerySelector, attr :: String }
   -> Aff (Array { element :: HTMLElement, attr :: String })
 selectElements { query, attr } = do
-  nodeArray <- liftEffect do 
+  nodeArray <- liftEffect do
     toArray =<< querySelectorAll query <<< toParentNode =<< document =<< window
-  let 
+  let
     elems = fromMaybe [] <<< sequence $ fromNode <$> nodeArray
   attrs <- liftEffect $ traverse (getAttribute attr <<< toElement) elems
   pure $ zipWith ({ element: _, attr: _ }) elems (fromMaybe "" <$> attrs)
@@ -104,4 +104,3 @@ typeahead = H.mkComponent
   }
   where
   label = SProxy :: SProxy "typeahead"
-

--- a/examples/Main.purs
+++ b/examples/Main.purs
@@ -88,7 +88,7 @@ dropdown :: forall t0 t1 t2. H.Component HH.HTML t0 t1 t2 Aff
 dropdown = H.mkComponent
   { initialState: const unit
   , render: \_ ->
-      HH.slot label unit (Select.component Dropdown.spec) (Dropdown.input input) \_ -> Nothing
+      HH.slot label unit Dropdown.component input \_ -> Nothing
   , eval: H.mkEval H.defaultEval
   }
   where
@@ -99,7 +99,7 @@ typeahead :: forall t0 t1 t2. H.Component HH.HTML t0 t1 t2 Aff
 typeahead = H.mkComponent
   { initialState: const unit
   , render: \_ ->
-      HH.slot label unit (Select.component Typeahead.spec) Typeahead.input \_ -> Nothing
+      HH.slot label unit Typeahead.component unit \_ -> Nothing
   , eval: H.mkEval H.defaultEval
   }
   where

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -176,8 +176,8 @@ component
   => (input -> Input st)
   -> Spec st query action slots input msg m
   -> H.Component HH.HTML (Query query slots) input msg m
-component initialState spec = H.mkComponent
-  { initialState: selectState <<< initialState
+component mkInput spec = H.mkComponent
+  { initialState: initialState <<< mkInput
   , render: spec.render
   , eval: H.mkEval $ H.defaultEval
       { handleQuery = handleQuery spec.handleQuery
@@ -188,8 +188,8 @@ component initialState spec = H.mkComponent
       }
   }
   where
-  selectState :: Input st -> State st
-  selectState = Builder.build pipeline
+  initialState :: Input st -> State st
+  initialState = Builder.build pipeline
     where
     pipeline =
       Builder.modify (SProxy :: _ "search") (fromMaybe "")

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -154,8 +154,9 @@ type Spec st query act ps input msg m =
 
 type Spec' st input m = Spec st (Const Void) Void () input Void m
 
-defaultSpec :: forall st query act ps input msg m
-             . Spec st query act ps input msg m
+defaultSpec
+  :: forall st query act ps input msg m
+   . Spec st query act ps input msg m
 defaultSpec =
   { render: const (HH.text mempty)
   , handleAction: const (pure unit)

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -172,10 +172,10 @@ component
   => Row.Lacks "debounceRef" st
   => Row.Lacks "visibility" st
   => Row.Lacks "highlightedIndex" st
-  => Spec st query act ps input msg m
-  -> (input -> Input st)
+  => (input -> Input st)
+  -> Spec st query act ps input msg m
   -> H.Component HH.HTML (Query query ps) input msg m
-component spec initialState = H.mkComponent
+component initialState spec = H.mkComponent
   { initialState: selectState <<< initialState
   , render: spec.render
   , eval: H.mkEval $ H.defaultEval

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -179,12 +179,12 @@ component
 component mkInput spec = H.mkComponent
   { initialState: initialState <<< mkInput
   , render: spec.render
-  , eval: H.mkEval $ H.defaultEval
-      { handleQuery = handleQuery spec.handleQuery
-      , handleAction = handleAction spec.handleAction spec.handleMessage
-      , initialize = Just (Initialize spec.initialize)
-      , receive = map Action <<< spec.receive
-      , finalize = map Action spec.finalize
+  , eval: H.mkEval
+      { handleQuery: handleQuery spec.handleQuery
+      , handleAction: handleAction spec.handleAction spec.handleMessage
+      , initialize: Just (Initialize spec.initialize)
+      , receive: map Action <<< spec.receive
+      , finalize: map Action spec.finalize
       }
   }
   where

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -116,35 +116,35 @@ type Input st =
   }
 
 type Spec st query act ps msg m =
-  { -- usual Halogen component spec 
-    render 
-      :: State st 
+  { -- usual Halogen component spec
+    render
+      :: State st
       -> H.ComponentHTML (Action act) ps m
-    
+
     -- handle additional actions provided to the component
-  , handleAction 
+  , handleAction
       :: act
       -> H.HalogenM (State st) (Action act) ps msg m Unit
 
     -- handle additional queries provided to the component
-  , handleQuery 
+  , handleQuery
       :: forall a
-       . query a 
+       . query a
       -> H.HalogenM (State st) (Action act) ps msg m (Maybe a)
 
     -- handle messages emitted by the component; provide H.raise to simply
     -- raise the Select messages to the parent.
-  , handleMessage 
+  , handleMessage
       :: Message
       -> H.HalogenM (State st) (Action act) ps msg m Unit
 
     -- optionally handle input on parent re-renders
-  , receive 
-      :: Input st 
+  , receive
+      :: Input st
       -> Maybe (Action act)
 
     -- perform some action when the component initializes.
-  , initialize 
+  , initialize
       :: Maybe (Action act)
 
     -- optionally perform some action on initialization. disabled by default.
@@ -155,7 +155,7 @@ type Spec st query act ps msg m =
 type Spec' st m = Spec st (Const Void) Void () Void m
 
 defaultSpec :: forall st query act ps msg m. Spec st query act ps msg m
-defaultSpec = 
+defaultSpec =
   { render: const (HH.text mempty)
   , handleAction: const (pure unit)
   , handleQuery: const (pure Nothing)
@@ -164,7 +164,7 @@ defaultSpec =
   , initialize: Nothing
   , finalize: Nothing
   }
-  
+
 component
   :: forall st query act ps msg m
    . MonadAff m
@@ -188,7 +188,7 @@ component spec = H.mkComponent
   initialState :: Input st -> State st
   initialState = Builder.build pipeline
     where
-    pipeline = 
+    pipeline =
       Builder.modify (SProxy :: _ "search") (fromMaybe "")
         >>> Builder.modify (SProxy :: _ "debounceTime") (fromMaybe mempty)
         >>> Builder.insert (SProxy :: _ "debounceRef") Nothing
@@ -223,7 +223,7 @@ handleAction handleAction' handleMessage = case _ of
     ref <- H.liftEffect $ Ref.new Nothing
     H.modify_ _ { debounceRef = Just ref }
     for_ mbAction handle
-  
+
   Search str -> do
     st <- H.get
     ref <- H.liftEffect $ map join $ traverse Ref.read st.debounceRef
@@ -341,6 +341,3 @@ handleAction handleAction' handleMessage = case _ of
 
     lastIndex :: State st -> Int
     lastIndex = (_ - 1) <<< st.getItemCount <<< userState
-
-
-

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -100,15 +100,15 @@ type ItemProps props =
 -- | with `mapWithIndex`:
 -- |
 -- | ```purescript
--- | renderItem index itemHTML = 
+-- | renderItem index itemHTML =
 -- |   HH.li (setItemProps index [ props ]) [ itemHTML ]
 -- |
 -- | render = renderItem `mapWithIndex` itemsArray
 -- | ```
 setItemProps
   :: forall props act
-   . Int 
-  -> Array (HP.IProp (ItemProps props) (Action act)) 
+   . Int
+  -> Array (HP.IProp (ItemProps props) (Action act))
   -> Array (HP.IProp (ItemProps props) (Action act))
 setItemProps index = append
   [ HE.onMouseDown \ev -> Just (Select (Index index) (Just ev))
@@ -125,4 +125,3 @@ setContainerProps
   -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action act))
 setContainerProps = append
   [ HE.onMouseDown $ Just <<< PreventClick ]
-


### PR DESCRIPTION
Fixes #44 (not the main focus of this PR, but was added later)

## What does this pull request do?

Before this PR, adding a select component as a child in a parent component would look like this:
```purescript
HH.slot label childIndex (S.component Component.spec) (Component.input input) messageHandler
```
This differs from the way Halogen would normally add a child in that only a component would be specified:
```purescript
HH.slot label childIndex component input messageHandler
```
It seems these two things (`Component.spec` and `Component.input`) were separated because one cannot provide a "default value" in `Select.defaultSpec` for the `initialState :: input -> Select.State stateRows` function. If one did add such a function to `Select.defaultSpec`, it ruins the record-updating syntax.
- Without that function, we'd write `S.defaultSpec { render = ... }`
- With that function, we'd write `(S.defaultSpec initialstate) { render = ... }`

This pull request makes two changes.

First, `Select.Component` has an additional argument `(input -> Input st)`. Now one can write
```purescript
selectComponent :: H.Component HH.HTML S.Query' Input Message Aff
selectComponent = S.component initialState $ S.defaultSpec
  { render = -- ...
  }
  where
    initialState :: input -> Input st
    initialState = -- implementation

    -- etc.
```
which looks a lot more like the Halogen component code we're used to. Moreover, it enables authors of this library to provide a "Select Component Template file" (similar to [`ComponentTemplate.purs`](https://github.com/JordanMartinez/learn-halogen/blob/latestRelease/src/05-ComponentTemplate-B.purs)) that people can copy-and-paste to help them get started with using this library.

Second, `Select.Spec` and `Select.Spec'` now take an additional type argument--`input`--and its `receive` function now receives a value of type `input` rather than `Input st`

Third, the Dropdown and Typeahead examples have been updated to use this new component-like syntax rather than the separate-spec-and-input syntax. 

Finally, my editor automatically removes extra whitespace in the files. Rather than fight it, I decided to add these as separate commits to make other commits cleaner to read.

## Where should the reviewer start?

Look at the examples folder's `Main.purs` and `Dropdown.purs`/`Typeahead.purs` files to see the difference. Then look at the `Select.component` function.

## How should this be manually tested?

Since this exposes what was hidden, I don't foresee a need to add any tests.

## Other Notes:

This PR could be further modified to include a "Select Component Template" file. **Edit:** Such a file was later added in this PR.
