### PR TITLE
Switch to using KeyboardEvent.key instead of KeyboardEvent.code

### DIFF
--- a/src/Select.purs
+++ b/src/Select.purs
@@ -296,12 +296,12 @@ handleAction handleAction' handleEvent = case _ of
   Key ev -> do
     void $ H.fork $ handle $ SetVisibility On
     let preventIt = H.liftEffect $ preventDefault $ KE.toEvent ev
-    case KE.code ev of
-      "ArrowUp" ->
+    case KE.key ev of
+      x | x == "ArrowUp" || x == "Up" ->
         preventIt *> handle (Highlight Prev)
-      "ArrowDown" ->
+      x | x == "ArrowDown" || x == "Down" ->
         preventIt *> handle (Highlight Next)
-      "Escape" -> do
+      x | x == "Escape" || x == "Esc" -> do
         inputElement <- H.getHTMLElementRef $ H.RefLabel "select-input"
         preventIt
         for_ inputElement (H.liftEffect <<< HTMLElement.blur)


### PR DESCRIPTION
## What does this pull request do?

Keyboard handling does not work in MS IE 11 and MS Edge as both browsers return "undefined" for `KeyboardEvent.code`. This PR changes the code to use `KeyboardEvent.key` instead.

In addition IE 11 returns "Up"/"Down"/"Esc" instead of "ArrowUp"/"ArrowDown"/"Escape".

## Where should the reviewer start?

To see it for yourself you can use https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code - there is a "Try it out" section where KeyboardEvent's key and code are displayed when pressing a key.

The PR only changes a couple of lines, so the review should be straightforward.

## How should this be manually tested?

Just run the examples pre-PR and test keyboard handling in IE11/Edge. Then apply the PR and re-test.
