### PR TITLE
Update Circle CI site image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   site:
     working_directory: ~/select
     docker:
-      - image: jfloff/alpine-python:3.4-slim
+      - image: jfloff/alpine-python:latest-slim
     steps:
       - checkout
 


### PR DESCRIPTION
## What does this pull request do?

Looks like the image we were using is no longer supported. Changing to rely on latest image instead. This may not be the best approach either, because new images might not support our needs, but pointing to a specific tag is more sure to break down the road than pointing to the latest one. Unless we want to point to a tag we control, which, may not be the worst idea.