### PR TITLE
Fix example for typeahead, s/selections/available

### DIFF
--- a/examples/Components/Typeahead.purs
+++ b/examples/Components/Typeahead.purs
@@ -177,7 +177,7 @@ component = Hooks.component \tokens _ -> Hooks.do
           RD.Loading -> renderMsg "Loading..."
           RD.Failure e -> renderMsg e
           RD.Success available'
-            | length selections > 0 -> renderItem `mapWithIndex` available'
+            | length available' > 0 -> renderItem `mapWithIndex` available'
             | otherwise -> renderMsg "No results found"
 
       renderItem index { name, population } =


### PR DESCRIPTION
I couldn't figure out how to run this to test, but when I used this example code for my own project, I found that this should probably refer to available, unless I'm missing something.